### PR TITLE
Update segments.py to handle uppercase file extensions

### DIFF
--- a/segments.py
+++ b/segments.py
@@ -38,7 +38,7 @@ def parseFolders(apath, rpath, allowed_filetypes={'audio': ['wav', 'flac', 'mp3'
     # Get all audio files
     for root, dirs, files in os.walk(apath):
         for f in files:
-            if f.split('.')[-1] in allowed_filetypes['audio']:
+            if f.split('.')[-1].lower() in allowed_filetypes['audio']:
                 data[f.rsplit('.', 1)[0]] = {'audio': os.path.join(root, f), 'result': ''}
 
     # Get all result files


### PR DESCRIPTION
First off, thanks for all your hard work on this project. We're excited about being able to use it. We just got our first test recordings back from the field and ran them through analyze.py and everything worked fine. We are using audiomoths and their file naming format is “YYYYMMDD_hhmmss.WAV” with a capitalized .WAV extension.

analyze.py seems to work fine since on line 37 of analyze.py you use a .lower() to convert the extension to lowercase. segments.py doesn't have this .lower() on line 41 so the dictionary named data doesn't get populated when running through the files in 'apath'. I forked this and made the change to line 41 in segments.py

`if f.split('.')[-1].lower() in allowed_filetypes['audio']:`

