### PR TITLE
fix: Dockerfile with ENTRYPOINT only section

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,4 @@ RUN pip3 install tensorflow
 COPY . ./
 
 # Add entry point to run the script
-ENTRYPOINT [ "python3" ]
-CMD [ "analyze.py" ]
+ENTRYPOINT [ "python3", "./analyze.py" ]


### PR DESCRIPTION
This is for convenience and alternatively to PR #51

AFAIK the combination of `ENTRYPOINT` and `CMD` section in _**Dockerfile**_ only makes sense if one needs the feature to overwrite the default command, specified by `CMD`, with a different one i.e. something like `analyze_test.py` specified on the command line.
My impression is, that this is never the case here, right?
If I'm right, it may be better to to go back in **_Dockerfile_** to `ENTRYPOINT [ "python3" , "./analyze.py" ]` and leave _README.md_ as it is?!