### PR TITLE
Write full error to err_log.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Logs
+error_log.txt
+
 # IDE/Editor settings
 .vscode/
 

--- a/analyze.py
+++ b/analyze.py
@@ -22,7 +22,7 @@ def clearErrorLog():
 def writeErrorLog(msg):
 
     with open(cfg.ERROR_LOG_FILE, 'a') as elog:
-        elog.write(msg + '\n')
+        elog.write(str(msg) + '\n')
 
 def parseInputFiles(path, allowed_filetypes=['wav', 'flac', 'mp3', 'ogg', 'm4a']):
 
@@ -234,14 +234,14 @@ def analyzeFile(item):
     # Status
     print('Analyzing {}'.format(fpath), flush=True)
 
-    # Open audio file and split into 3-second chunks
-    chunks = getRawAudioFromFile(fpath)
+    try:
+        # Open audio file and split into 3-second chunks
+        chunks = getRawAudioFromFile(fpath)
 
     # If no chunks, show error and skip
-    if len(chunks) == 0:
-        msg = 'Error: Cannot open audio file {}'.format(fpath)
-        print(msg, flush=True)
-        writeErrorLog(msg)
+    except Exception as ex:
+        print('Error: Cannot open audio file {}'.format(fpath), flush=True)
+        writeErrorLog(ex)
         return False
 
     # Process each chunk

--- a/audio.py
+++ b/audio.py
@@ -9,10 +9,7 @@ def openAudioFile(path, sample_rate=48000, offset=0.0, duration=None):
     # Open file with librosa (uses ffmpeg or libav)
     import librosa
 
-    try:
-        sig, rate = librosa.load(path, sr=sample_rate, offset=offset, duration=duration, mono=True, res_type='kaiser_fast')
-    except:
-        sig, rate = [], sample_rate
+    sig, rate = librosa.load(path, sr=sample_rate, offset=offset, duration=duration, mono=True, res_type='kaiser_fast')
 
     return sig, rate
 

--- a/segments.py
+++ b/segments.py
@@ -19,7 +19,7 @@ def clearErrorLog():
 def writeErrorLog(msg):
 
     with open(cfg.ERROR_LOG_FILE, 'a') as elog:
-        elog.write(msg + '\n')
+        elog.write(str(msg) + '\n')
 
 def detectRType(line):
 
@@ -160,8 +160,12 @@ def extractSegments(item):
     # Status
     print('Extracting segments from {}'.format(afile))
 
-    # Open audio file
-    sig, rate = audio.openAudioFile(afile, cfg.SAMPLE_RATE)
+    try:
+        # Open audio file
+        sig, _ = audio.openAudioFile(afile, cfg.SAMPLE_RATE)
+    except Exception as ex:
+        print('Error: Cannot open audio file {}'.format(afile), flush=True)
+        writeErrorLog(ex)
 
     # Extract segments
     seg_cnt = 1

--- a/segments.py
+++ b/segments.py
@@ -166,6 +166,7 @@ def extractSegments(item):
     except Exception as ex:
         print('Error: Cannot open audio file {}'.format(afile), flush=True)
         writeErrorLog(ex)
+        return
 
     # Extract segments
     seg_cnt = 1


### PR DESCRIPTION
I updated the code to write the full error message to the `error_log.txt` if a librosa was not able to open an audio file for whatever reason.

But that also means the function `getRawAudioFromFile` can now throw an exception, so pls check for sanity @kahst.