### PR TITLE
added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 librosa
 resampy
 tensorflow
+bottles
 gradio
 pyqt5
 pygobject

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy
+librosa
+resampy
+tensorflow
+gradio
+pyqt5
+pygobject
+pywebview


### PR DESCRIPTION
tested with analyze, gui, server and train
todo: version pinning
I had to create a python 3.10 environment.
With python 3.11, required package numba-0.56.4 will not install.