### PR TITLE
respect LOCATION_FILTER_THRESHOLD config, adjust sf_thresh range from 0.0001 to 0.99

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -394,7 +394,7 @@ if __name__ == '__main__':
     parser.add_argument('--threads', type=int, default=4, help='Number of CPU threads.')
     parser.add_argument('--batchsize', type=int, default=1, help='Number of samples to process at the same time. Defaults to 1.')
     parser.add_argument('--locale', default='en', help='Locale for translated species common names. Values in [\'af\', \'de\', \'it\', ...] Defaults to \'en\'.')
-    parser.add_argument('--sf_thresh', type=float, default=0.03, help='Minimum species occurrence frequency threshold for location filter. Values in [0.01, 0.99]. Defaults to 0.03.')
+    parser.add_argument('--sf_thresh', type=float, help='Minimum species occurrence frequency threshold for location filter. Values in [0.01, 0.99]. Defaults to 0.03.')
     parser.add_argument('--classifier', default=None, help='Path to custom trained classifier. Defaults to None. If set, --lat, --lon and --locale are ignored.') 
 
     args = parser.parse_args()
@@ -431,7 +431,10 @@ if __name__ == '__main__':
 
     # Load species list from location filter or provided list
     cfg.LATITUDE, cfg.LONGITUDE, cfg.WEEK = args.lat, args.lon, args.week
-    cfg.LOCATION_FILTER_THRESHOLD = max(0.01, min(0.99, float(args.sf_thresh)))
+    if args.sf_thresh is not None:
+        cfg.LOCATION_FILTER_THRESHOLD = max(0.01, min(0.99, float(args.sf_thresh)))
+    if args.sf_thresh is None and cfg.LOCATION_FILTER_THRESHOLD is None:
+        cfg.LOCATION_FILTER_THRESHOLD = 0.03
     if cfg.LATITUDE == -1 and cfg.LONGITUDE == -1:
         if len(args.slist) == 0:
             cfg.SPECIES_LIST_FILE = None

--- a/analyze.py
+++ b/analyze.py
@@ -394,7 +394,7 @@ if __name__ == '__main__':
     parser.add_argument('--threads', type=int, default=4, help='Number of CPU threads.')
     parser.add_argument('--batchsize', type=int, default=1, help='Number of samples to process at the same time. Defaults to 1.')
     parser.add_argument('--locale', default='en', help='Locale for translated species common names. Values in [\'af\', \'de\', \'it\', ...] Defaults to \'en\'.')
-    parser.add_argument('--sf_thresh', type=float, help='Minimum species occurrence frequency threshold for location filter. Values in [0.01, 0.99]. Defaults to 0.03.')
+    parser.add_argument('--sf_thresh', type=float, help='Minimum species occurrence frequency threshold for location filter. Values in [0.0001, 0.99]. Defaults to 0.03.')
     parser.add_argument('--classifier', default=None, help='Path to custom trained classifier. Defaults to None. If set, --lat, --lon and --locale are ignored.') 
 
     args = parser.parse_args()
@@ -432,7 +432,7 @@ if __name__ == '__main__':
     # Load species list from location filter or provided list
     cfg.LATITUDE, cfg.LONGITUDE, cfg.WEEK = args.lat, args.lon, args.week
     if args.sf_thresh is not None:
-        cfg.LOCATION_FILTER_THRESHOLD = max(0.01, min(0.99, float(args.sf_thresh)))
+        cfg.LOCATION_FILTER_THRESHOLD = max(0.0001, min(0.99, float(args.sf_thresh)))
     if args.sf_thresh is None and cfg.LOCATION_FILTER_THRESHOLD is None:
         cfg.LOCATION_FILTER_THRESHOLD = 0.03
     if cfg.LATITUDE == -1 and cfg.LONGITUDE == -1:


### PR DESCRIPTION
before: 
-you set LOCATION_FILTER_THRESHOLD in config, and it was not respected, instead the default value of 0.03 was used.
-only a part of the species list could be adressed with sf_thresh (between 0.01 to 0.99)

after:
-first the config value is used, if the "--sf_thresh" is set, then this value is used, if no config value and no "--sf_thresh" value is set, the default (0.03) is used.
-the full species list can be adressed with sf_thresh (0.0001 to 0.99)
TODO: use a method of argparse, to see whether "--sf_thresh" is set.