### PR TITLE
Add locale labels for en_uk

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -402,7 +402,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--locale",
         default="en",
-        help="Locale for translated species common names. Values in ['af', 'de', 'it', ...] Defaults to 'en'.",
+        help="Locale for translated species common names. Values in ['af', 'en_UK', 'de', 'it', ...] Defaults to 'en' (US English).",
     )
     parser.add_argument(
         "--sf_thresh",

--- a/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt
+++ b/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_en_uk.txt
@@ -1,0 +1,6522 @@
+Abroscopus albogularis_Rufous-faced Warbler
+Abroscopus schisticeps_Black-faced Warbler
+Abroscopus superciliaris_Yellow-bellied Warbler
+Aburria aburri_Wattled Guan
+Acanthagenys rufogularis_Spiny-cheeked Honeyeater
+Acanthidops bairdi_Peg-billed Finch
+Acanthis cabaret_Lesser Redpoll
+Acanthis flammea_Common Redpoll
+Acanthis hornemanni_Arctic Redpoll
+Acanthisitta chloris_Rifleman
+Acanthiza apicalis_Inland Thornbill
+Acanthiza chrysorrhoa_Yellow-rumped Thornbill
+Acanthiza ewingii_Tasmanian Thornbill
+Acanthiza inornata_Western Thornbill
+Acanthiza lineata_Striated Thornbill
+Acanthiza nana_Yellow Thornbill
+Acanthiza pusilla_Brown Thornbill
+Acanthiza reguloides_Buff-rumped Thornbill
+Acanthiza uropygialis_Chestnut-rumped Thornbill
+Acanthorhynchus superciliosus_Western Spinebill
+Acanthorhynchus tenuirostris_Eastern Spinebill
+Accipiter badius_Shikra
+Accipiter bicolor_Bicoloured Hawk
+Accipiter cirrocephalus_Collared Sparrowhawk
+Accipiter cooperii_Cooper's Hawk
+Accipiter fasciatus_Brown Goshawk
+Accipiter gentilis_Eurasian Goshawk
+Accipiter gularis_Japanese Sparrowhawk
+Accipiter hiogaster_Variable Goshawk
+Accipiter melanoleucus_Black Goshawk
+Accipiter minullus_Little Sparrowhawk
+Accipiter nisus_Eurasian Sparrowhawk
+Accipiter novaehollandiae_Grey Goshawk
+Accipiter poliogaster_Grey-bellied Hawk
+Accipiter soloensis_Chinese Sparrowhawk
+Accipiter striatus_Sharp-shinned Hawk
+Accipiter superciliosus_Tiny Hawk
+Accipiter tachiro_African Goshawk
+Accipiter trinotatus_Spot-tailed Goshawk
+Accipiter trivirgatus_Crested Goshawk
+Accipiter virgatus_Besra
+Aceros nipalensis_Rufous-necked Hornbill
+Achaetops pycnopygius_Rockrunner
+Acridotheres burmannicus_Burmese Myna
+Acridotheres cristatellus_Crested Myna
+Acridotheres fuscus_Jungle Myna
+Acridotheres ginginianus_Bank Myna
+Acridotheres grandis_Great Myna
+Acridotheres javanicus_Javan Myna
+Acridotheres tristis_Common Myna
+Acris crepitans_Northern Cricket Frog
+Acris gryllus_Southern Cricket Frog
+Acrobatornis fonsecai_Pink-legged Graveteiro
+Acrocephalus agricola_Paddyfield Warbler
+Acrocephalus arundinaceus_Great Reed Warbler
+Acrocephalus australis_Australian Reed Warbler
+Acrocephalus baeticatus_African Reed Warbler
+Acrocephalus bistrigiceps_Black-browed Reed Warbler
+Acrocephalus concinens_Blunt-winged Warbler
+Acrocephalus dumetorum_Blyth's Reed Warbler
+Acrocephalus gracilirostris_Lesser Swamp Warbler
+Acrocephalus griseldis_Basra Reed Warbler
+Acrocephalus melanopogon_Moustached Warbler
+Acrocephalus newtoni_Madagascar Swamp Warbler
+Acrocephalus orientalis_Oriental Reed Warbler
+Acrocephalus paludicola_Aquatic Warbler
+Acrocephalus palustris_Marsh Warbler
+Acrocephalus rufescens_Greater Swamp Warbler
+Acrocephalus schoenobaenus_Sedge Warbler
+Acrocephalus scirpaceus_Common Reed Warbler
+Acrocephalus stentoreus_Clamorous Reed Warbler
+Acrocephalus tangorum_Manchurian Reed Warbler
+Acropternis orthonyx_Ocellated Tapaculo
+Actenoides concretus_Rufous-collared Kingfisher
+Actenoides lindsayi_Spotted Kingfisher
+Actenoides monachus_Green-backed Kingfisher
+Actinodura cyanouroptera_Blue-winged Minla
+Actinodura egertoni_Rusty-fronted Barwing
+Actinodura nipalensis_Hoary-throated Barwing
+Actinodura ramsayi_Spectacled Barwing
+Actinodura strigula_Chestnut-tailed Minla
+Actinodura waldeni_Streak-throated Barwing
+Actitis hypoleucos_Common Sandpiper
+Actitis macularius_Spotted Sandpiper
+Actophilornis africanus_African Jacana
+Adelomyia melanogenys_Speckled Hummingbird
+Aechmophorus clarkii_Clark's Grebe
+Aechmophorus occidentalis_Western Grebe
+Aegithalos caudatus_Long-tailed Tit
+Aegithalos concinnus_Black-throated Tit
+Aegithalos glaucogularis_Silver-throated Tit
+Aegithalos iouschistos_Black-browed Tit
+Aegithalos niveogularis_White-throated Tit
+Aegithina nigrolutea_White-tailed Iora
+Aegithina tiphia_Common Iora
+Aegithina viridissima_Green Iora
+Aegolius acadicus_Northern Saw-whet Owl
+Aegolius funereus_Tengmalm's Owl
+Aegolius harrisii_Buff-fronted Owl
+Aegolius ridgwayi_Unspotted Saw-whet Owl
+Aegotheles cristatus_Australian Owlet-nightjar
+Aegypius monachus_Black Vulture
+Aerodramus bartschi_Mariana Swiftlet
+Aerodramus fuciphagus_White-nest Swiftlet
+Aerodramus maximus_Black-nest Swiftlet
+Aeronautes andecolus_Andean Swift
+Aeronautes montivagus_White-tipped Swift
+Aeronautes saxatalis_White-throated Swift
+Aethia pusilla_Least Auklet
+Aethia pygmaea_Whiskered Auklet
+Aethopyga christinae_Fork-tailed Sunbird
+Aethopyga gouldiae_Mrs. Gould's Sunbird
+Aethopyga ignicauda_Fire-tailed Sunbird
+Aethopyga nipalensis_Green-tailed Sunbird
+Aethopyga saturata_Black-throated Sunbird
+Aethopyga siparaja_Crimson Sunbird
+Aethopyga temminckii_Temminck's Sunbird
+Aethopyga vigorsii_Vigors's Sunbird
+Agapornis canus_Grey-headed Lovebird
+Agapornis fischeri_Fischer's Lovebird
+Agapornis personatus_Yellow-collared Lovebird
+Agapornis roseicollis_Rosy-faced Lovebird
+Agapornis taranta_Black-winged Lovebird
+Agelaioides badius_Greyish Baywing
+Agelaius phoeniceus_Red-winged Blackbird
+Agelaius tricolor_Tricoloured Blackbird
+Agelasticus cyanopus_Unicoloured Blackbird
+Agelasticus thilius_Yellow-winged Blackbird
+Agelasticus xanthophthalmus_Pale-eyed Blackbird
+Aglaiocercus coelestis_Violet-tailed Sylph
+Aglaiocercus kingii_Long-tailed Sylph
+Agriornis montanus_Black-billed Shrike-Tyrant
+Agropsar philippensis_Chestnut-cheeked Starling
+Agropsar sturninus_Daurian Starling
+Ailuroedus crassirostris_Green Catbird
+Ailuroedus maculosus_Spotted Catbird
+Aimophila notosticta_Oaxaca Sparrow
+Aimophila rufescens_Rusty Sparrow
+Aimophila ruficeps_Rufous-crowned Sparrow
+Aix galericulata_Mandarin Duck
+Aix sponsa_Wood Duck
+Akletos goeldii_Goeldi's Antbird
+Akletos melanoceps_White-shouldered Antbird
+Alaemon alaudipes_Greater Hoopoe-Lark
+Alauda arvensis_Eurasian Skylark
+Alauda gulgula_Oriental Skylark
+Alaudala cheleensis_Asian Short-toed Lark
+Alaudala heinei_Turkestan Short-toed Lark
+Alaudala raytal_Sand Lark
+Alaudala rufescens_Mediterranean Short-toed Lark
+Alaudala somalica_Somali Short-toed Lark
+Alca torda_Razorbill
+Alcedo atthis_Common Kingfisher
+Alcedo meninting_Blue-eared Kingfisher
+Alcippe brunneicauda_Brown Fulvetta
+Alcippe fratercula_Yunnan Fulvetta
+Alcippe hueti_Huet's Fulvetta
+Alcippe morrisonia_Morrison's Fulvetta
+Alcippe nipalensis_Nepal Fulvetta
+Alcippe peracensis_Mountain Fulvetta
+Alcippe poioicephala_Brown-cheeked Fulvetta
+Alcippe pyrrhoptera_Javan Fulvetta
+Aleadryas rufinucha_Rufous-naped Bellbird
+Alectoris barbara_Barbary Partridge
+Alectoris chukar_Chukar
+Alectoris graeca_Rock Partridge
+Alectoris rufa_Red-legged Partridge
+Alectura lathami_Australian Brushturkey
+Alethe castanea_Fire-crested Alethe
+Alethe diademata_White-tailed Alethe
+Alipiopsitta xanthops_Yellow-faced Parrot
+Alisterus scapularis_Australian King-Parrot
+Allenia fusca_Scaly-breasted Thrasher
+Allonemobius allardi_Allard's Ground Cricket
+Allonemobius tinnulus_Tinkling Ground Cricket
+Allonemobius walkeri_Walker's Ground Cricket
+Alophoixus finschii_Finsch's Bulbul
+Alophoixus flaveolus_White-throated Bulbul
+Alophoixus ochraceus_Ochraceous Bulbul
+Alophoixus pallidus_Puff-throated Bulbul
+Alophoixus phaeocephalus_Yellow-bellied Bulbul
+Alophoixus tephrogenys_Grey-cheeked Bulbul
+Alopochelidon fucata_Tawny-headed Swallow
+Alopochen aegyptiaca_Egyptian Goose
+Alouatta pigra_Mexican Black Howler Monkey
+Amalocichla incerta_Lesser Ground-Robin
+Amandava amandava_Red Avadavat
+Amaurolimnas concolor_Uniform Crake
+Amaurornis isabellina_Isabelline Bush-hen
+Amaurornis moluccana_Pale-vented Bush-hen
+Amaurornis phoenicurus_White-breasted Waterhen
+Amaurospiza concolor_Blue Seedeater
+Amaurospiza moesta_Blackish-blue Seedeater
+Amazilia luciae_Honduran Emerald
+Amazilia rutila_Cinnamon Hummingbird
+Amazilia tzacatl_Rufous-tailed Hummingbird
+Amazilia yucatanensis_Buff-bellied Hummingbird
+Amazilis amazilia_Amazilia Hummingbird
+Amazona aestiva_Turquoise-fronted Parrot
+Amazona agilis_Black-billed Parrot
+Amazona albifrons_White-fronted Parrot
+Amazona amazonica_Orange-winged Parrot
+Amazona auropalliata_Yellow-naped Parrot
+Amazona autumnalis_Red-lored Parrot
+Amazona brasiliensis_Red-tailed Parrot
+Amazona dufresniana_Blue-cheeked Parrot
+Amazona farinosa_Mealy Parrot
+Amazona festiva_Festive Parrot
+Amazona finschi_Lilac-crowned Parrot
+Amazona kawalli_Kawall's Parrot
+Amazona leucocephala_Cuban Parrot
+Amazona mercenarius_Scaly-naped Parrot
+Amazona ochrocephala_Yellow-crowned Parrot
+Amazona oratrix_Yellow-headed Parrot
+Amazona rhodocorytha_Red-browed Parrot
+Amazona tucumana_Tucuman Parrot
+Amazona ventralis_Hispaniolan Parrot
+Amazona vinacea_Vinaceous-breasted Parrot
+Amazona viridigenalis_Red-crowned Parrot
+Amazona xantholora_Yellow-lored Parrot
+Amazonetta brasiliensis_Brazilian Teal
+Amblycercus holosericeus_Yellow-billed Cacique
+Amblycorypha alexanderi_Clicker Round-winged Katydid
+Amblycorypha longinicta_Common Virtuoso Katydid
+Amblycorypha oblongifolia_Oblong-winged Katydid
+Amblycorypha rotundifolia_Rattler Round-winged Katydid
+Amblyornis newtoniana_Golden Bowerbird
+Amblyospiza albifrons_Grosbeak Weaver
+Amblyramphus holosericeus_Scarlet-headed Blackbird
+Ammodramus aurifrons_Yellow-browed Sparrow
+Ammodramus humeralis_Grassland Sparrow
+Ammodramus savannarum_Grasshopper Sparrow
+Ammomanes cinctura_Bar-tailed Lark
+Ammomanes deserti_Desert Lark
+Ammomanes phoenicura_Rufous-tailed Lark
+Ammonastes pelzelni_Grey-bellied Antbird
+Ammospiza caudacuta_Saltmarsh Sparrow
+Ammospiza leconteii_LeConte's Sparrow
+Ammospiza maritima_Seaside Sparrow
+Ammospiza nelsoni_Nelson's Sparrow
+Ampelioides tschudii_Scaled Fruiteater
+Ampelion rubrocristatus_Red-crested Cotinga
+Ampelion rufaxilla_Chestnut-crested Cotinga
+Ampelornis griseiceps_Grey-headed Antbird
+Amphispiza bilineata_Black-throated Sparrow
+Amphispizopsis quinquestriata_Five-striped Sparrow
+Anabacerthia amaurotis_White-browed Foliage-gleaner
+Anabacerthia lichtensteini_Ochre-breasted Foliage-gleaner
+Anabacerthia ruficaudata_Rufous-tailed Foliage-gleaner
+Anabacerthia striaticollis_Montane Foliage-gleaner
+Anabacerthia variegaticeps_Scaly-throated Foliage-gleaner
+Anabazenops dorsalis_Dusky-cheeked Foliage-gleaner
+Anabazenops fuscus_White-collared Foliage-gleaner
+Anairetes alpinus_Ash-breasted Tit-Tyrant
+Anairetes flavirostris_Yellow-billed Tit-Tyrant
+Anairetes nigrocristatus_Black-crested Tit-Tyrant
+Anairetes parulus_Tufted Tit-Tyrant
+Anairetes reguloides_Pied-crested Tit-Tyrant
+Anas acuta_Northern Pintail
+Anas andium_Andean Teal
+Anas castanea_Chestnut Teal
+Anas crecca_Eurasian/Green-winged Teal
+Anas diazi_Mexican Duck
+Anas flavirostris_Yellow-billed Teal
+Anas fulvigula_Mottled Duck
+Anas georgica_Yellow-billed Pintail
+Anas gracilis_Grey Teal
+Anas platyrhynchos_Mallard
+Anas poecilorhyncha_Indian Spot-billed Duck
+Anas rubripes_American Black Duck
+Anas superciliosa_Pacific Black Duck
+Anas undulata_Yellow-billed Duck
+Anas wyvilliana_Hawaiian Duck
+Anas zonorhyncha_Eastern Spot-billed Duck
+Anastomus oscitans_Asian Openbill
+Anaxipha exigua_Say's Trig
+Anaxyrus americanus_American Toad
+Anaxyrus canorus_Yosemite Toad
+Anaxyrus cognatus_Great Plains Toad
+Anaxyrus fowleri_Fowler's Toad
+Anaxyrus houstonensis_Houston Toad
+Anaxyrus microscaphus_Arizona Toad
+Anaxyrus quercicus_Oak Toad
+Anaxyrus speciosus_Texas Toad
+Anaxyrus terrestris_Southern Toad
+Anaxyrus woodhousii_Woodhouse's Toad
+Ancistrops strigilatus_Chestnut-winged Hookbill
+Andigena hypoglauca_Grey-breasted Mountain-Toucan
+Andigena laminirostris_Plate-billed Mountain-Toucan
+Andigena nigrirostris_Black-billed Mountain-Toucan
+Androdon aequatorialis_Tooth-billed Hummingbird
+Andropadus importunus_Sombre Greenbul
+Anhima cornuta_Horned Screamer
+Anhinga anhinga_Anhinga
+Anhinga melanogaster_Oriental Darter
+Anhinga novaehollandiae_Australasian Darter
+Anisognathus igniventris_Scarlet-bellied Mountain Tanager
+Anisognathus lacrymosus_Lacrimose Mountain Tanager
+Anisognathus somptuosus_Blue-winged Mountain Tanager
+Anodorhynchus hyacinthinus_Hyacinth Macaw
+Anodorhynchus leari_Indigo Macaw
+Anorrhinus galeritus_Bushy-crested Hornbill
+Anous ceruleus_Blue-grey Noddy
+Anous minutus_Black Noddy
+Anous stolidus_Brown Noddy
+Anous tenuirostris_Lesser Noddy
+Anser albifrons_Greater White-fronted Goose
+Anser anser_Greylag Goose
+Anser brachyrhynchus_Pink-footed Goose
+Anser caerulescens_Snow Goose
+Anser canagicus_Emperor Goose
+Anser cygnoides_Swan Goose
+Anser erythropus_Lesser White-fronted Goose
+Anser fabalis_Taiga Bean Goose
+Anser indicus_Bar-headed Goose
+Anser rossii_Ross's Goose
+Anser serrirostris_Tundra Bean Goose
+Anseranas semipalmata_Magpie Goose
+Anthipes monileger_White-gorgeted Flycatcher
+Anthipes solitaris_Rufous-browed Flycatcher
+Anthobaphes violacea_Orange-breasted Sunbird
+Anthochaera carunculata_Red Wattlebird
+Anthochaera chrysoptera_Little Wattlebird
+Anthochaera lunulata_Western Wattlebird
+Anthochaera paradoxa_Yellow Wattlebird
+Anthochaera phrygia_Regent Honeyeater
+Anthornis melanura_New Zealand Bellbird
+Anthoscopus minutus_Southern Penduline Tit
+Anthoscopus musculus_Mouse-coloured Penduline Tit
+Anthracoceros albirostris_Oriental Pied-Hornbill
+Anthracoceros coronatus_Malabar Pied-Hornbill
+Anthracoceros malayanus_Black Hornbill
+Anthracothorax nigricollis_Black-throated Mango
+Anthreptes malacensis_Brown-throated Sunbird
+Anthreptes orientalis_Eastern Violet-backed Sunbird
+Anthropoides paradiseus_Blue Crane
+Anthropoides virgo_Demoiselle Crane
+Anthus berthelotii_Berthelot's Pipit
+Anthus bogotensis_Paramo Pipit
+Anthus campestris_Tawny Pipit
+Anthus cervinus_Red-throated Pipit
+Anthus chacoensis_Pampas Pipit
+Anthus cinnamomeus_African Pipit
+Anthus correndera_Correndera Pipit
+Anthus crenatus_Yellow-tufted Pipit
+Anthus furcatus_Short-billed Pipit
+Anthus godlewskii_Blyth's Pipit
+Anthus gustavi_Pechora Pipit
+Anthus hellmayri_Hellmayr's Pipit
+Anthus hodgsoni_Olive-backed Pipit
+Anthus leucophrys_Plain-backed Pipit
+Anthus lineiventris_Striped Pipit
+Anthus lutescens_Yellowish Pipit
+Anthus nattereri_Ochre-breasted Pipit
+Anthus novaeseelandiae_New Zealand Pipit
+Anthus peruvianus_Peruvian Pipit
+Anthus petrosus_Rock Pipit
+Anthus pratensis_Meadow Pipit
+Anthus richardi_Richard's Pipit
+Anthus roseatus_Rosy Pipit
+Anthus rubescens_Buff-bellied Pipit
+Anthus rufulus_Paddyfield Pipit
+Anthus similis_Long-billed Pipit
+Anthus spinoletta_Water Pipit
+Anthus spragueii_Sprague's Pipit
+Anthus sylvanus_Upland Pipit
+Anthus trivialis_Tree Pipit
+Antigone antigone_Sarus Crane
+Antigone canadensis_Sandhill Crane
+Antigone rubicunda_Brolga
+Antigone vipio_White-naped Crane
+Antilophia bokermanni_Araripe Manakin
+Antilophia galeata_Helmeted Manakin
+Antrostomus arizonae_Mexican Whip-poor-will
+Antrostomus badius_Yucatan Nightjar
+Antrostomus carolinensis_Chuck-will's-widow
+Antrostomus noctitherus_Puerto Rican Nightjar
+Antrostomus ridgwayi_Buff-collared Nightjar
+Antrostomus rufus_Rufous Nightjar
+Antrostomus salvini_Tawny-collared Nightjar
+Antrostomus saturatus_Dusky Nightjar
+Antrostomus sericocaudatus_Silky-tailed Nightjar
+Antrostomus vociferus_Eastern Whip-poor-will
+Anumbius annumbi_Firewood-gatherer
+Anurolimnas castaneiceps_Chestnut-headed Crake
+Anurolimnas fasciatus_Black-banded Crake
+Anurolimnas viridis_Russet-crowned Crake
+Apalis alticola_Brown-headed Apalis
+Apalis chapini_Chapin's Apalis
+Apalis cinerea_Grey Apalis
+Apalis flavida_Yellow-breasted Apalis
+Apalis jacksoni_Black-throated Apalis
+Apalis melanocephala_Black-headed Apalis
+Apalis personata_Black-faced Apalis
+Apalis porphyrolaema_Chestnut-throated Apalis
+Apalis ruddi_Rudd's Apalis
+Apalis rufogularis_Buff-throated Apalis
+Apalis sharpii_Sharpe's Apalis
+Apalis thoracica_Bar-throated Apalis
+Apaloderma narina_Narina Trogon
+Apaloderma vittatum_Bar-tailed Trogon
+Aphanotriccus audax_Black-billed Flycatcher
+Aphanotriccus capitalis_Tawny-chested Flycatcher
+Aphelocephala leucopsis_Southern Whiteface
+Aphelocoma californica_California Scrub-Jay
+Aphelocoma coerulescens_Florida Scrub-Jay
+Aphelocoma ultramarina_Transvolcanic Jay
+Aphelocoma unicolor_Unicoloured Jay
+Aphelocoma wollweberi_Mexican Jay
+Aphelocoma woodhouseii_Woodhouse's Scrub-Jay
+Aphrastura spinicauda_Thorn-tailed Rayadito
+Apis mellifera_Honey Bee
+Aplonis atrifusca_Samoan Starling
+Aplonis grandis_Brown-winged Starling
+Aplonis metallica_Metallic Starling
+Aplonis mysolensis_Moluccan Starling
+Aplonis opaca_Micronesian Starling
+Aplonis panayensis_Asian Glossy Starling
+Aplonis tabuensis_Polynesian Starling
+Aprosmictus erythropterus_Red-winged Parrot
+Aptenodytes patagonicus_King Penguin
+Apteryx mantelli_North Island Brown Kiwi
+Apus affinis_Little Swift
+Apus apus_Common Swift
+Apus caffer_White-rumped Swift
+Apus melba_Alpine Swift
+Apus nipalensis_House Swift
+Apus pacificus_Pacific Swift
+Apus pallidus_Pallid Swift
+Apus unicolor_Plain Swift
+Aquila adalberti_Spanish Eagle
+Aquila chrysaetos_Golden Eagle
+Aquila heliaca_Imperial Eagle
+Aquila nipalensis_Steppe Eagle
+Ara ambiguus_Great Green Macaw
+Ara ararauna_Blue-and-yellow Macaw
+Ara chloropterus_Red-and-green Macaw
+Ara glaucogularis_Blue-throated Macaw
+Ara macao_Scarlet Macaw
+Ara militaris_Military Macaw
+Ara severus_Chestnut-fronted Macaw
+Arachnothera chrysogenys_Yellow-eared Spiderhunter
+Arachnothera crassirostris_Thick-billed Spiderhunter
+Arachnothera flavigaster_Spectacled Spiderhunter
+Arachnothera longirostra_Little Spiderhunter
+Arachnothera magna_Streaked Spiderhunter
+Aramides albiventris_Russet-naped Wood-Rail
+Aramides axillaris_Rufous-necked Wood-Rail
+Aramides cajaneus_Grey-cowled Wood-Rail
+Aramides saracura_Slaty-breasted Wood-Rail
+Aramides wolfi_Brown Wood-Rail
+Aramides ypecaha_Giant Wood-Rail
+Aramus guarauna_Limpkin
+Aratinga auricapillus_Golden-capped Parakeet
+Aratinga jandaya_Jandaya Parakeet
+Aratinga nenday_Nanday Parakeet
+Aratinga weddellii_Dusky-headed Parakeet
+Arborophila atrogularis_White-cheeked Partridge
+Arborophila brunneopectus_Bar-backed Partridge
+Arborophila crudigularis_Taiwan Partridge
+Arborophila hyperythra_Red-breasted Partridge
+Arborophila javanica_Chestnut-bellied Partridge
+Arborophila mandellii_Chestnut-breasted Partridge
+Arborophila rufogularis_Rufous-throated Partridge
+Arborophila torqueola_Hill Partridge
+Archilochus alexandri_Black-chinned Hummingbird
+Archilochus colubris_Ruby-throated Hummingbird
+Ardea alba_Great White Egret
+Ardea cinerea_Grey Heron
+Ardea cocoi_Cocoi Heron
+Ardea herodias_Great Blue Heron
+Ardea intermedia_Medium Egret
+Ardea melanocephala_Black-headed Heron
+Ardea purpurea_Purple Heron
+Ardea sumatrana_Great-billed Heron
+Ardenna bulleri_Buller's Shearwater
+Ardenna carneipes_Flesh-footed Shearwater
+Ardenna creatopus_Pink-footed Shearwater
+Ardenna grisea_Sooty Shearwater
+Ardenna pacifica_Wedge-tailed Shearwater
+Ardenna tenuirostris_Short-tailed Shearwater
+Ardeola bacchus_Chinese Pond Heron
+Ardeola grayii_Indian Pond Heron
+Ardeola ralloides_Squacco Heron
+Ardeola speciosa_Javan Pond Heron
+Arenaria interpres_Ruddy Turnstone
+Arenaria melanocephala_Black Turnstone
+Argusianus argus_Great Argus
+Argya affinis_Yellow-billed Babbler
+Argya caudata_Common Babbler
+Argya earlei_Striated Babbler
+Argya malcolmi_Large Grey Babbler
+Argya striata_Jungle Babbler
+Argya subrufa_Rufous Babbler
+Arizelocichla masukuensis_Shelley's Greenbul
+Arizelocichla milanjensis_Stripe-cheeked Greenbul
+Arizelocichla nigriceps_Eastern Mountain Greenbul
+Arremon abeillei_Black-capped Sparrow
+Arremon assimilis_Grey-browed Brushfinch
+Arremon atricapillus_Black-headed Brushfinch
+Arremon aurantiirostris_Orange-billed Sparrow
+Arremon basilicus_Sierra Nevada Brushfinch
+Arremon brunneinucha_Chestnut-capped Brushfinch
+Arremon castaneiceps_Olive Finch
+Arremon costaricensis_Costa Rican Brushfinch
+Arremon crassirostris_Sooty-faced Finch
+Arremon flavirostris_Saffron-billed Sparrow
+Arremon franciscanus_Sao Francisco Sparrow
+Arremon perijanus_Perija Brushfinch
+Arremon schlegeli_Golden-winged Sparrow
+Arremon semitorquatus_Half-collared Sparrow
+Arremon taciturnus_Pectoral Sparrow
+Arremon torquatus_White-browed Brushfinch
+Arremon virenticeps_Green-striped Brushfinch
+Arremonops chloronotus_Green-backed Sparrow
+Arremonops conirostris_Black-striped Sparrow
+Arremonops rufivirgatus_Olive Sparrow
+Arremonops tocuyensis_Tocuyo Sparrow
+Arses telescopthalmus_Frilled Monarch
+Artamus cinereus_Black-faced Woodswallow
+Artamus cyanopterus_Dusky Woodswallow
+Artamus fuscus_Ashy Woodswallow
+Artamus leucorynchus_White-breasted Woodswallow
+Artamus personatus_Masked Woodswallow
+Artamus superciliosus_White-browed Woodswallow
+Artemisiospiza belli_Bell's Sparrow
+Artemisiospiza nevadensis_Sagebrush Sparrow
+Artisornis metopias_African Tailorbird
+Artisornis moreaui_Long-billed Tailorbird
+Arundinax aedon_Thick-billed Warbler
+Arundinicola leucocephala_White-headed Marsh Tyrant
+Asemospiza fuliginosa_Sooty Grassquit
+Asemospiza obscura_Dull-coloured Grassquit
+Asio clamator_Striped Owl
+Asio flammeus_Short-eared Owl
+Asio grammicus_Jamaican Owl
+Asio otus_Long-eared Owl
+Asio stygius_Stygian Owl
+Aspatha gularis_Blue-throated Motmot
+Asthenes anthoides_Austral Canastero
+Asthenes baeri_Short-billed Canastero
+Asthenes coryi_Ochre-browed Thistletail
+Asthenes dorbignyi_Creamy-breasted Canastero
+Asthenes flammulata_Many-striped Canastero
+Asthenes fuliginosa_White-chinned Thistletail
+Asthenes griseomurina_Mouse-coloured Thistletail
+Asthenes harterti_Black-throated Thistletail
+Asthenes helleri_Puna Thistletail
+Asthenes heterura_Maquis Canastero
+Asthenes hudsoni_Hudson's Canastero
+Asthenes humilis_Streak-throated Canastero
+Asthenes maculicauda_Scribble-tailed Canastero
+Asthenes modesta_Cordilleran Canastero
+Asthenes moreirae_Itatiaia Spinetail
+Asthenes ottonis_Rusty-fronted Canastero
+Asthenes palpebralis_Eye-ringed Thistletail
+Asthenes perijana_Perija Thistletail
+Asthenes pudibunda_Canyon Canastero
+Asthenes pyrrholeuca_Sharp-billed Canastero
+Asthenes sclateri_Puna Canastero
+Asthenes urubambensis_Line-fronted Canastero
+Asthenes virgata_Junin Canastero
+Asthenes wyatti_Streak-backed Canastero
+Atalotriccus pilaris_Pale-eyed Pygmy-Tyrant
+Atelornis crossleyi_Rufous-headed Ground-Roller
+Atelornis pittoides_Pitta-like Ground-Roller
+Athene blewitti_Forest Owlet
+Athene brama_Spotted Owlet
+Athene cunicularia_Burrowing Owl
+Athene noctua_Little Owl
+Athene superciliaris_White-browed Owl
+Atimastillas flavicollis_Yellow-throated Greenbul
+Atlanticus testaceus_Protean Shieldback
+Atlapetes albinucha_White-naped Brushfinch
+Atlapetes albofrenatus_Moustached Brushfinch
+Atlapetes citrinellus_Yellow-striped Brushfinch
+Atlapetes flaviceps_Yellow-headed Brushfinch
+Atlapetes fulviceps_Fulvous-headed Brushfinch
+Atlapetes fuscoolivaceus_Dusky-headed Brushfinch
+Atlapetes latinuchus_Yellow-breasted Brushfinch
+Atlapetes leucopis_White-rimmed Brushfinch
+Atlapetes leucopterus_White-winged Brushfinch
+Atlapetes melanocephalus_Santa Marta Brushfinch
+Atlapetes melanolaemus_Black-faced Brushfinch
+Atlapetes pallidiceps_Pale-headed Brushfinch
+Atlapetes pallidinucha_Pale-naped Brushfinch
+Atlapetes personatus_Tepui Brushfinch
+Atlapetes pileatus_Rufous-capped Brushfinch
+Atlapetes rufigenis_Rufous-eared Brushfinch
+Atlapetes rufinucha_Bolivian Brushfinch
+Atlapetes schistaceus_Slaty Brushfinch
+Atlapetes semirufus_Ochre-breasted Brushfinch
+Atlapetes tibialis_Yellow-thighed Brushfinch
+Atlapetes tricolor_Tricoloured Brushfinch
+Atrichornis clamosus_Noisy Scrub-bird
+Atrichornis rufescens_Rufous Scrub-bird
+Attagis gayi_Rufous-bellied Seedsnipe
+Atticora fasciata_White-banded Swallow
+Atticora pileata_Black-capped Swallow
+Atticora tibialis_White-thighed Swallow
+Attila bolivianus_Dull-capped Attila
+Attila cinnamomeus_Cinnamon Attila
+Attila citriniventris_Citron-bellied Attila
+Attila phoenicurus_Rufous-tailed Attila
+Attila rufus_Grey-hooded Attila
+Attila spadiceus_Bright-rumped Attila
+Attila torridus_Ochraceous Attila
+Augastes lumachella_Hooded Visorbearer
+Augastes scutatus_Hyacinth Visorbearer
+Aulacorhynchus albivitta_Southern Emerald-Toucanet
+Aulacorhynchus coeruleicinctis_Blue-banded Toucanet
+Aulacorhynchus derbianus_Chestnut-tipped Toucanet
+Aulacorhynchus haematopygus_Crimson-rumped Toucanet
+Aulacorhynchus prasinus_Northern Emerald-Toucanet
+Aulacorhynchus sulcatus_Groove-billed Toucanet
+Auriparus flaviceps_Verdin
+Automolus exsertus_Chiriqui Foliage-gleaner
+Automolus infuscatus_Olive-backed Foliage-gleaner
+Automolus leucophthalmus_White-eyed Foliage-gleaner
+Automolus melanopezus_Brown-rumped Foliage-gleaner
+Automolus ochrolaemus_Ochre-throated Foliage-gleaner
+Automolus paraensis_Para Foliage-gleaner
+Automolus rufipileatus_Chestnut-crowned Foliage-gleaner
+Automolus subulatus_Eastern Woodhaunter
+Aviceda jerdoni_Jerdon's Baza
+Aviceda leuphotes_Black Baza
+Aviceda subcristata_Pacific Baza
+Aythya affinis_Lesser Scaup
+Aythya americana_Redhead
+Aythya collaris_Ring-necked Duck
+Aythya ferina_Common Pochard
+Aythya fuligula_Tufted Duck
+Aythya marila_Greater Scaup
+Aythya nyroca_Ferruginous Duck
+Aythya valisineria_Canvasback
+Baeolophus atricristatus_Black-crested Titmouse
+Baeolophus bicolor_Tufted Titmouse
+Baeolophus inornatus_Oak Titmouse
+Baeolophus ridgwayi_Juniper Titmouse
+Baeolophus wollweberi_Bridled Titmouse
+Baeopogon indicator_Honeyguide Greenbul
+Balearica regulorum_Grey Crowned-Crane
+Bambusicola fytchii_Mountain Bamboo-Partridge
+Bambusicola sonorivox_Taiwan Bamboo-Partridge
+Bambusicola thoracicus_Chinese Bamboo-Partridge
+Bangsia aureocincta_Gold-ringed Tanager
+Bangsia edwardsi_Moss-backed Tanager
+Bangsia melanochlamys_Black-and-gold Tanager
+Barnardius zonarius_Australian Ringneck
+Bartramia longicauda_Upland Sandpiper
+Baryphthengus martii_Rufous Motmot
+Baryphthengus ruficapillus_Rufous-capped Motmot
+Basileuterus belli_Golden-browed Warbler
+Basileuterus culicivorus_Golden-crowned Warbler
+Basileuterus delattrii_Chestnut-capped Warbler
+Basileuterus lachrymosus_Mexican Fan-tailed Warbler
+Basileuterus melanogenys_Black-cheeked Warbler
+Basileuterus melanotis_Costa Rican Warbler
+Basileuterus rufifrons_Rufous-capped Warbler
+Basileuterus trifasciatus_Three-banded Warbler
+Basileuterus tristriatus_Three-striped Warbler
+Basilinna leucotis_White-eared Hummingbird
+Batara cinerea_Giant Antshrike
+Bathmocercus rufus_Black-faced Rufous-Warbler
+Batis capensis_Cape Batis
+Batis erlangeri_Western Black-headed Batis
+Batis mixta_Short-tailed Batis
+Batis molitor_Chinspot Batis
+Batis orientalis_Grey-headed Batis
+Batis perkeo_Pygmy Batis
+Batis pririt_Pririt Batis
+Batis soror_Pale Batis
+Batrachostomus affinis_Blyth's Frogmouth
+Batrachostomus auritus_Large Frogmouth
+Batrachostomus cornutus_Sunda Frogmouth
+Batrachostomus hodgsoni_Hodgson's Frogmouth
+Batrachostomus moniliger_Sri Lanka Frogmouth
+Batrachostomus septimus_Philippine Frogmouth
+Batrachostomus stellatus_Gould's Frogmouth
+Berenicornis comatus_White-crowned Hornbill
+Berlepschia rikeri_Point-tailed Palmcreeper
+Bernieria madagascariensis_Long-billed Bernieria
+Bias musicus_Black-and-white Shrike-flycatcher
+Biatas nigropectus_White-bearded Antshrike
+Biziura lobata_Musk Duck
+Bleda canicapillus_Grey-headed Bristlebill
+Bleda notatus_Lesser Bristlebill
+Bleda syndactylus_Red-tailed Bristlebill
+Blythipicus pyrrhotis_Bay Woodpecker
+Blythipicus rubiginosus_Maroon Woodpecker
+Boissonneaua flavescens_Buff-tailed Coronet
+Boissonneaua jardini_Velvet-purple Coronet
+Boissonneaua matthewsii_Chestnut-breasted Coronet
+Bolbopsittacus lunulatus_Guaiabero
+Bolborhynchus lineola_Barred Parakeet
+Bolborhynchus orbygnesius_Andean Parakeet
+Bolemoreus frenatus_Bridled Honeyeater
+Bombycilla cedrorum_Cedar Waxwing
+Bombycilla garrulus_Bohemian Waxwing
+Bombycilla japonica_Japanese Waxwing
+Bonasa umbellus_Ruffed Grouse
+Bostrychia carunculata_Wattled Ibis
+Bostrychia hagedash_Hadada Ibis
+Botaurus lentiginosus_American Bittern
+Botaurus stellaris_Great Bittern
+Brachygalba albogularis_White-throated Jacamar
+Brachygalba lugubris_Brown Jacamar
+Brachypodius eutilotus_Puff-backed Bulbul
+Brachypodius melanocephalos_Black-headed Bulbul
+Brachypodius melanoleucos_Black-and-white Bulbul
+Brachypodius priocephalus_Gray-headed Bulbul
+Brachypodius urostictus_Yellow-wattled Bulbul
+Brachypteryx cruralis_Himalayan Shortwing
+Brachypteryx goodfellowi_Taiwan Shortwing
+Brachypteryx hyperythra_Rusty-bellied Shortwing
+Brachypteryx leucophris_Lesser Shortwing
+Brachypteryx montana_Javan Shortwing
+Brachyramphus marmoratus_Marbled Murrelet
+Bradornis microrhynchus_African Grey Flycatcher
+Bradypterus baboecala_Little Rush Warbler
+Bradypterus barratti_Barratt's Warbler
+Bradypterus brunneus_Brown Emutail
+Bradypterus carpalis_White-winged Swamp Warbler
+Bradypterus cinnamomeus_Cinnamon Bracken-Warbler
+Bradypterus lopezi_Evergreen-forest Warbler
+Bradypterus sylvaticus_Knysna Warbler
+Branta bernicla_Brent Goose
+Branta canadensis_Canada Goose
+Branta hutchinsii_Cackling Goose
+Branta leucopsis_Barnacle Goose
+Branta sandvicensis_Hawaiian Goose
+Brotogeris chiriri_Yellow-chevroned Parakeet
+Brotogeris chrysoptera_Golden-winged Parakeet
+Brotogeris cyanoptera_Cobalt-winged Parakeet
+Brotogeris jugularis_Orange-chinned Parakeet
+Brotogeris pyrrhoptera_Grey-cheeked Parakeet
+Brotogeris sanctithomae_Tui Parakeet
+Brotogeris tirica_Plain Parakeet
+Brotogeris versicolurus_White-winged Parakeet
+Bubalornis albirostris_White-billed Buffalo-Weaver
+Bubalornis niger_Red-billed Buffalo-Weaver
+Bubo africanus_Spotted Eagle Owl
+Bubo bengalensis_Rock Eagle Owl
+Bubo bubo_Eurasian Eagle Owl
+Bubo coromandus_Dusky Eagle-Owl
+Bubo lacteus_Verreaux's Eagle-Owl
+Bubo nipalensis_Spot-bellied Eagle-Owl
+Bubo scandiacus_Snowy Owl
+Bubo sumatranus_Barred Eagle-Owl
+Bubo virginianus_Great Horned Owl
+Bubulcus ibis_Western Cattle Egret
+Bucanetes githagineus_Trumpeter Finch
+Buccanodon duchaillui_Yellow-spotted Barbet
+Bucco capensis_Collared Puffbird
+Bucco macrodactylus_Chestnut-capped Puffbird
+Bucco tamatia_Spotted Puffbird
+Bucephala albeola_Bufflehead
+Bucephala clangula_Common Goldeneye
+Bucephala islandica_Barrow's Goldeneye
+Buceros bicornis_Great Hornbill
+Buceros hydrocorax_Rufous Hornbill
+Buceros rhinoceros_Rhinoceros Hornbill
+Buceros vigil_Helmeted Hornbill
+Bucorvus leadbeateri_Southern Ground-Hornbill
+Bulweria bulwerii_Bulwer's Petrel
+Buphagus africanus_Yellow-billed Oxpecker
+Buphagus erythrorynchus_Red-billed Oxpecker
+Burhinus bistriatus_Double-striped Thick-knee
+Burhinus capensis_Spotted Thick-knee
+Burhinus grallarius_Bush Thick-knee
+Burhinus indicus_Indian Thick-knee
+Burhinus oedicnemus_Stone-curlew
+Burhinus senegalensis_Senegal Thick-knee
+Burhinus superciliaris_Peruvian Thick-knee
+Burhinus vermiculatus_Water Thick-knee
+Busarellus nigricollis_Black-collared Hawk
+Butastur indicus_Grey-faced Buzzard
+Butastur teesa_White-eyed Buzzard
+Buteo albigula_White-throated Hawk
+Buteo albonotatus_Zone-tailed Hawk
+Buteo augur_Augur Buzzard
+Buteo brachypterus_Madagascar Buzzard
+Buteo brachyurus_Short-tailed Hawk
+Buteo buteo_Common Buzzard
+Buteo jamaicensis_Red-tailed Hawk
+Buteo japonicus_Eastern Buzzard
+Buteo lagopus_Rough-legged Buzzard
+Buteo lineatus_Red-shouldered Hawk
+Buteo nitidus_Grey-lined Hawk
+Buteo oreophilus_Mountain Buzzard
+Buteo plagiatus_Grey Hawk
+Buteo platypterus_Broad-winged Hawk
+Buteo regalis_Ferruginous Hawk
+Buteo ridgwayi_Ridgway's Hawk
+Buteo solitarius_Hawaiian Hawk
+Buteo swainsoni_Swainson's Hawk
+Buteogallus anthracinus_Common Black Hawk
+Buteogallus coronatus_Chaco Eagle
+Buteogallus meridionalis_Savanna Hawk
+Buteogallus schistaceus_Slate-coloured Hawk
+Buteogallus solitarius_Solitary Eagle
+Buteogallus urubitinga_Great Black Hawk
+Buthraupis montana_Hooded Mountain Tanager
+Butorides striata_Striated Heron
+Butorides virescens_Green Heron
+Bycanistes albotibialis_White-thighed Hornbill
+Bycanistes brevis_Silvery-cheeked Hornbill
+Bycanistes bucinator_Trumpeter Hornbill
+Bycanistes fistulator_Piping Hornbill
+Bycanistes subcylindricus_Black-and-white-casqued Hornbill
+Cacatua alba_White Cockatoo
+Cacatua ducorpsii_Ducorps's Cockatoo
+Cacatua galerita_Sulphur-crested Cockatoo
+Cacatua goffiniana_Tanimbar Corella
+Cacatua sanguinea_Little Corella
+Cacatua tenuirostris_Long-billed Corella
+Cacicus cela_Yellow-rumped Cacique
+Cacicus chrysonotus_Mountain Cacique
+Cacicus chrysopterus_Golden-winged Cacique
+Cacicus haemorrhous_Red-rumped Cacique
+Cacicus latirostris_Band-tailed Cacique
+Cacicus oseryi_Casqued Cacique
+Cacicus solitarius_Solitary Black Cacique
+Cacicus uropygialis_Scarlet-rumped Cacique
+Cacomantis castaneiventris_Chestnut-breasted Cuckoo
+Cacomantis flabelliformis_Fan-tailed Cuckoo
+Cacomantis leucolophus_White-crowned Cuckoo
+Cacomantis merulinus_Plaintive Cuckoo
+Cacomantis pallidus_Pallid Cuckoo
+Cacomantis passerinus_Grey-bellied Cuckoo
+Cacomantis sonneratii_Banded Bay Cuckoo
+Cacomantis variolosus_Brush Cuckoo
+Cairina moschata_Muscovy Duck
+Calamanthus fuliginosus_Striated Fieldwren
+Calamonastes fasciolatus_Barred Wren-Warbler
+Calamonastes simplex_Grey Wren-Warbler
+Calamonastes stierlingi_Stierling's Wren-Warbler
+Calamospiza melanocorys_Lark Bunting
+Calandrella acutirostris_Hume's Lark
+Calandrella brachydactyla_Greater Short-toed Lark
+Calandrella cinerea_Red-capped Lark
+Calandrella dukhunensis_Mongolian Short-toed Lark
+Calcarius lapponicus_Lapland Bunting
+Calcarius ornatus_Chestnut-collared Longspur
+Calcarius pictus_Smith's Longspur
+Calendulauda africanoides_Fawn-coloured Lark
+Calendulauda albescens_Karoo Lark
+Calendulauda alopex_Foxy Lark
+Calendulauda poecilosterna_Pink-breasted Lark
+Calendulauda sabota_Sabota Lark
+Calicalicus madagascariensis_Red-tailed Vanga
+Calidris acuminata_Sharp-tailed Sandpiper
+Calidris alba_Sanderling
+Calidris alpina_Dunlin
+Calidris bairdii_Baird's Sandpiper
+Calidris canutus_Red Knot
+Calidris falcinellus_Broad-billed Sandpiper
+Calidris ferruginea_Curlew Sandpiper
+Calidris fuscicollis_White-rumped Sandpiper
+Calidris himantopus_Stilt Sandpiper
+Calidris maritima_Purple Sandpiper
+Calidris mauri_Western Sandpiper
+Calidris melanotos_Pectoral Sandpiper
+Calidris minuta_Little Stint
+Calidris minutilla_Least Sandpiper
+Calidris ptilocnemis_Rock Sandpiper
+Calidris pugnax_Ruff
+Calidris pusilla_Semipalmated Sandpiper
+Calidris pygmaea_Spoon-billed Sandpiper
+Calidris ruficollis_Red-necked Stint
+Calidris subminuta_Long-toed Stint
+Calidris subruficollis_Buff-breasted Sandpiper
+Calidris temminckii_Temminck's Stint
+Calidris tenuirostris_Great Knot
+Calidris virgata_Surfbird
+Caligavis chrysops_Yellow-faced Honeyeater
+Caligavis subfrenata_Black-throated Honeyeater
+Callacanthis burtoni_Spectacled Finch
+Callaeas wilsoni_North Island Kokako
+Calliope calliope_Siberian Rubythroat
+Calliope pectardens_Firethroat
+Calliope pectoralis_Himalayan Rubythroat
+Calliope tschebaiewi_Chinese Rubythroat
+Callipepla californica_California Quail
+Callipepla douglasii_Elegant Quail
+Callipepla gambelii_Gambel's Quail
+Callipepla squamata_Scaled Quail
+Callocephalon fimbriatum_Gang-gang Cockatoo
+Calocitta colliei_Black-throated Magpie-Jay
+Calocitta formosa_White-throated Magpie-Jay
+Calonectris diomedea_Cory's Shearwater
+Caloramphus fuliginosus_Brown Barbet
+Calothorax lucifer_Lucifer Hummingbird
+Calypte anna_Anna's Hummingbird
+Calypte costae_Costa's Hummingbird
+Calyptomena viridis_Green Broadbill
+Calyptomena whiteheadi_Whitehead's Broadbill
+Calyptophilus frugivorus_Eastern Chat-Tanager
+Calyptophilus tertius_Western Chat-Tanager
+Calyptorhynchus banksii_Red-tailed Black-Cockatoo
+Calyptorhynchus funereus_Yellow-tailed Black-Cockatoo
+Calyptorhynchus lathami_Glossy Black-Cockatoo
+Calyptorhynchus latirostris_Carnaby's Black-Cockatoo
+Camaroptera brachyura_Green-backed Camaroptera
+Camaroptera chloronota_Olive-green Camaroptera
+Camaroptera superciliaris_Yellow-browed Camaroptera
+Campephaga flava_Black Cuckooshrike
+Campephaga quiscalina_Purple-throated Cuckooshrike
+Campephilus gayaquilensis_Guayaquil Woodpecker
+Campephilus guatemalensis_Pale-billed Woodpecker
+Campephilus haematogaster_Crimson-bellied Woodpecker
+Campephilus leucopogon_Cream-backed Woodpecker
+Campephilus magellanicus_Magellanic Woodpecker
+Campephilus melanoleucos_Crimson-crested Woodpecker
+Campephilus pollens_Powerful Woodpecker
+Campephilus robustus_Robust Woodpecker
+Campephilus rubricollis_Red-necked Woodpecker
+Campethera abingoni_Golden-tailed Woodpecker
+Campethera cailliautii_Green-backed Woodpecker
+Campethera mombassica_Mombasa Woodpecker
+Campethera nubica_Nubian Woodpecker
+Camptostoma imberbe_Northern Beardless-Tyrannulet
+Camptostoma obsoletum_Southern Beardless-Tyrannulet
+Campylopterus falcatus_Lazuline Sabrewing
+Campylopterus hemileucurus_Violet Sabrewing
+Campylopterus largipennis_Grey-breasted Sabrewing
+Campylorhamphus falcularius_Black-billed Scythebill
+Campylorhamphus procurvoides_Curve-billed Scythebill
+Campylorhamphus pusillus_Brown-billed Scythebill
+Campylorhamphus trochilirostris_Red-billed Scythebill
+Campylorhynchus albobrunneus_White-headed Wren
+Campylorhynchus brunneicapillus_Cactus Wren
+Campylorhynchus chiapensis_Giant Wren
+Campylorhynchus fasciatus_Fasciated Wren
+Campylorhynchus griseus_Bicoloured Wren
+Campylorhynchus gularis_Spotted Wren
+Campylorhynchus jocosus_Boucard's Wren
+Campylorhynchus megalopterus_Grey-barred Wren
+Campylorhynchus nuchalis_Stripe-backed Wren
+Campylorhynchus rufinucha_Rufous-naped Wren
+Campylorhynchus turdinus_Thrush-like Wren
+Campylorhynchus yucatanicus_Yucatan Wren
+Campylorhynchus zonatus_Band-backed Wren
+Canachites canadensis_Spruce Grouse
+Canis latrans_Coyote
+Canis lupus_Gray Wolf
+Cantorchilus elutus_Isthmian Wren
+Cantorchilus guarayanus_Fawn-breasted Wren
+Cantorchilus leucopogon_Stripe-throated Wren
+Cantorchilus leucotis_Buff-breasted Wren
+Cantorchilus longirostris_Long-billed Wren
+Cantorchilus modestus_Cabanis's Wren
+Cantorchilus nigricapillus_Bay Wren
+Cantorchilus semibadius_Riverside Wren
+Cantorchilus superciliaris_Superciliated Wren
+Cantorchilus thoracicus_Stripe-breasted Wren
+Cantorchilus zeledoni_Canebrake Wren
+Capito auratus_Gilded Barbet
+Capito aurovirens_Scarlet-crowned Barbet
+Capito dayi_Black-girdled Barbet
+Capito hypoleucus_White-mantled Barbet
+Capito niger_Black-spotted Barbet
+Capito quinticolor_Five-coloured Barbet
+Capito squamatus_Orange-fronted Barbet
+Capito wallacei_Scarlet-banded Barbet
+Caprimulgus affinis_Savanna Nightjar
+Caprimulgus asiaticus_Indian Nightjar
+Caprimulgus atripennis_Jerdon's Nightjar
+Caprimulgus clarus_Slender-tailed Nightjar
+Caprimulgus climacurus_Long-tailed Nightjar
+Caprimulgus europaeus_Eurasian Nightjar
+Caprimulgus fossii_Square-tailed Nightjar
+Caprimulgus indicus_Jungle Nightjar
+Caprimulgus jotaka_Grey Nightjar
+Caprimulgus macrurus_Large-tailed Nightjar
+Caprimulgus madagascariensis_Madagascar Nightjar
+Caprimulgus manillensis_Philippine Nightjar
+Caprimulgus natalensis_Swamp Nightjar
+Caprimulgus nigriscapularis_Black-shouldered Nightjar
+Caprimulgus pectoralis_Fiery-necked Nightjar
+Caprimulgus poliocephalus_Montane Nightjar
+Caprimulgus ruficollis_Red-necked Nightjar
+Caprimulgus rufigena_Rufous-cheeked Nightjar
+Caprimulgus tristigma_Freckled Nightjar
+Capsiempis flaveola_Yellow Tyrannulet
+Caracara plancus_Crested Caracara
+Cardellina canadensis_Canada Warbler
+Cardellina pusilla_Wilson's Warbler
+Cardellina rubra_Red Warbler
+Cardellina rubrifrons_Red-faced Warbler
+Cardellina versicolor_Pink-headed Warbler
+Cardinalis cardinalis_Northern Cardinal
+Cardinalis phoeniceus_Vermilion Cardinal
+Cardinalis sinuatus_Pyrrhuloxia
+Carduelis carduelis_European Goldfinch
+Carduelis citrinella_Citril Finch
+Carduelis corsicana_Corsican Finch
+Cariama cristata_Red-legged Seriema
+Carpococcyx radiceus_Bornean Ground-Cuckoo
+Carpococcyx renauldi_Coral-billed Ground-Cuckoo
+Carpodacus dubius_Chinese White-browed Rosefinch
+Carpodacus erythrinus_Common Rosefinch
+Carpodacus puniceus_Red-fronted Rosefinch
+Carpodacus rodochroa_Pink-browed Rosefinch
+Carpodacus rubicilla_Great Rosefinch
+Carpodacus rubicilloides_Streaked Rosefinch
+Carpodacus sibiricus_Long-tailed Rosefinch
+Carpodacus synoicus_Sinai Rosefinch
+Carpodacus thura_Himalayan White-browed Rosefinch
+Carpornis cucullata_Hooded Berryeater
+Carpornis melanocephala_Black-headed Berryeater
+Carpospiza brachydactyla_Pale Rockfinch
+Carterornis chrysomela_Golden Monarch
+Carterornis leucotis_White-eared Monarch
+Carterornis pileatus_White-naped Monarch
+Caryothraustes canadensis_Yellow-green Grosbeak
+Caryothraustes poliogaster_Black-faced Grosbeak
+Casiornis rufus_Rufous Casiornis
+Cassiculus melanicterus_Yellow-winged Cacique
+Casuarius casuarius_Southern Cassowary
+Catamblyrhynchus diadema_Plushcap
+Catamenia analis_Band-tailed Seedeater
+Catamenia homochroa_Paramo Seedeater
+Catamenia inornata_Plain-coloured Seedeater
+Cathartes aura_Turkey Vulture
+Catharus aurantiirostris_Orange-billed Nightingale-Thrush
+Catharus bicknelli_Bicknell's Thrush
+Catharus dryas_Yellow-throated Nightingale-Thrush
+Catharus frantzii_Ruddy-capped Nightingale-Thrush
+Catharus fuscater_Slaty-backed Nightingale-Thrush
+Catharus fuscescens_Veery
+Catharus gracilirostris_Black-billed Nightingale-Thrush
+Catharus guttatus_Hermit Thrush
+Catharus maculatus_Speckled Nightingale-Thrush
+Catharus mexicanus_Black-headed Nightingale-Thrush
+Catharus minimus_Grey-cheeked Thrush
+Catharus occidentalis_Russet Nightingale-Thrush
+Catharus ustulatus_Swainson's Thrush
+Catherpes mexicanus_Canyon Wren
+Catreus wallichii_Cheer Pheasant
+Cecropis abyssinica_Lesser Striped Swallow
+Cecropis cucullata_Greater Striped Swallow
+Cecropis daurica_Red-rumped Swallow
+Cecropis semirufa_Rufous-chested Swallow
+Cecropis striolata_Striated Swallow
+Celeus castaneus_Chestnut-coloured Woodpecker
+Celeus elegans_Chestnut Woodpecker
+Celeus flavescens_Blond-crested Woodpecker
+Celeus flavus_Cream-coloured Woodpecker
+Celeus galeatus_Helmeted Woodpecker
+Celeus grammicus_Scale-breasted Woodpecker
+Celeus loricatus_Cinnamon Woodpecker
+Celeus lugubris_Pale-crested Woodpecker
+Celeus obrieni_Kaempfer's Woodpecker
+Celeus ochraceus_Ochre-backed Woodpecker
+Celeus spectabilis_Rufous-headed Woodpecker
+Celeus torquatus_Ringed Woodpecker
+Celeus undatus_Waved Woodpecker
+Centrocercus urophasianus_Greater Sage-Grouse
+Centronyx bairdii_Baird's Sparrow
+Centronyx henslowii_Henslow's Sparrow
+Centropus andamanensis_Andaman Coucal
+Centropus bengalensis_Lesser Coucal
+Centropus celebensis_Bay Coucal
+Centropus chlororhynchos_Green-billed Coucal
+Centropus leucogaster_Black-throated Coucal
+Centropus melanops_Black-faced Coucal
+Centropus menbeki_Greater Black Coucal
+Centropus milo_Buff-headed Coucal
+Centropus monachus_Blue-headed Coucal
+Centropus phasianinus_Pheasant Coucal
+Centropus rectunguis_Short-toed Coucal
+Centropus senegalensis_Senegal Coucal
+Centropus sinensis_Greater Coucal
+Centropus superciliosus_White-browed Coucal
+Centropus toulou_Malagasy Coucal
+Centropus viridis_Philippine Coucal
+Cephalopterus penduliger_Long-wattled Umbrellabird
+Cepphus columba_Pigeon Guillemot
+Cepphus grylle_Black Guillemot
+Ceratogymna atrata_Black-casqued Hornbill
+Ceratopipra chloromeros_Round-tailed Manakin
+Ceratopipra cornuta_Scarlet-horned Manakin
+Ceratopipra erythrocephala_Golden-headed Manakin
+Ceratopipra mentalis_Red-capped Manakin
+Ceratopipra rubrocapilla_Red-headed Manakin
+Cercibis oxycerca_Sharp-tailed Ibis
+Cercococcyx mechowi_Dusky Long-tailed Cuckoo
+Cercococcyx montanus_Barred Long-tailed Cuckoo
+Cercococcyx olivinus_Olive Long-tailed Cuckoo
+Cercomacra brasiliana_Rio de Janeiro Antbird
+Cercomacra carbonaria_Rio Branco Antbird
+Cercomacra cinerascens_Grey Antbird
+Cercomacra ferdinandi_Bananal Antbird
+Cercomacra manu_Manu Antbird
+Cercomacra melanaria_Mato Grosso Antbird
+Cercomacra nigricans_Jet Antbird
+Cercomacroides fuscicauda_Riparian Antbird
+Cercomacroides laeta_Willis's Antbird
+Cercomacroides nigrescens_Blackish Antbird
+Cercomacroides parkeri_Parker's Antbird
+Cercomacroides serva_Black Antbird
+Cercomacroides tyrannina_Dusky Antbird
+Cercotrichas barbata_Miombo Scrub Robin
+Cercotrichas coryphoeus_Karoo Scrub Robin
+Cercotrichas galactotes_Rufous-tailed Scrub Robin
+Cercotrichas hartlaubi_Brown-backed Scrub Robin
+Cercotrichas leucophrys_Red-backed Scrub Robin
+Cercotrichas paena_Kalahari Scrub Robin
+Cercotrichas podobe_Black Scrub Robin
+Cercotrichas quadrivirgata_Bearded Scrub Robin
+Cercotrichas signata_Brown Scrub Robin
+Certhia americana_Brown Creeper
+Certhia brachydactyla_Short-toed Treecreeper
+Certhia discolor_Sikkim Treecreeper
+Certhia familiaris_Eurasian Treecreeper
+Certhia himalayana_Bar-tailed Treecreeper
+Certhia hodgsoni_Hodgson's Treecreeper
+Certhia manipurensis_Hume's Treecreeper
+Certhiasomus stictolaemus_Spot-throated Woodcreeper
+Certhiaxis cinnamomeus_Yellow-chinned Spinetail
+Certhiaxis mustelinus_Red-and-white Spinetail
+Certhilauda chuana_Short-clawed Lark
+Certhilauda semitorquata_Eastern Long-billed Lark
+Certhilauda subcoronata_Karoo Long-billed Lark
+Certhionyx variegatus_Pied Honeyeater
+Ceryle rudis_Pied Kingfisher
+Cettia brunnifrons_Grey-sided Bush Warbler
+Cettia castaneocoronata_Chestnut-headed Tesia
+Cettia cetti_Cetti's Warbler
+Cettia major_Chestnut-crowned Bush Warbler
+Ceuthmochares aereus_Blue Malkoha
+Ceuthmochares australis_Green Malkoha
+Ceyx azureus_Azure Kingfisher
+Ceyx erithaca_Black-backed Dwarf-Kingfisher
+Chaetocercus mulsant_White-bellied Woodstar
+Chaetops frenatus_Cape Rockjumper
+Chaetura brachyura_Short-tailed Swift
+Chaetura chapmani_Chapman's Swift
+Chaetura cinereiventris_Grey-rumped Swift
+Chaetura meridionalis_Sick's Swift
+Chaetura pelagica_Chimney Swift
+Chaetura spinicaudus_Band-rumped Swift
+Chaetura vauxi_Vaux's Swift
+Chalcomitra amethystina_Amethyst Sunbird
+Chalcomitra senegalensis_Scarlet-chested Sunbird
+Chalcoparia singalensis_Ruby-cheeked Sunbird
+Chalcophaps indica_Asian Emerald Dove
+Chalcophaps longirostris_Pacific Emerald Dove
+Chalcophaps stephani_Stephan's Dove
+Chalybura buffonii_White-vented Plumeleteer
+Chalybura urochrysia_Bronze-tailed Plumeleteer
+Chamaea fasciata_Wrentit
+Chamaepetes goudotii_Sickle-winged Guan
+Chamaepetes unicolor_Black Guan
+Chamaetylas fuelleborni_White-chested Alethe
+Chamaetylas poliocephala_Brown-chested Alethe
+Chamaeza campanisona_Short-tailed Antthrush
+Chamaeza meruloides_Such's Antthrush
+Chamaeza mollissima_Barred Antthrush
+Chamaeza nobilis_Striated Antthrush
+Chamaeza ruficauda_Rufous-tailed Antthrush
+Chamaeza turdina_Schwartz's Antthrush
+Charadrius alexandrinus_Kentish Plover
+Charadrius bicinctus_Double-banded Plover
+Charadrius collaris_Collared Plover
+Charadrius dubius_Little Ringed Plover
+Charadrius falklandicus_Two-banded Plover
+Charadrius hiaticula_Common Ringed Plover
+Charadrius javanicus_Javan Plover
+Charadrius leschenaultii_Greater Sand-Plover
+Charadrius melodus_Piping Plover
+Charadrius modestus_Rufous-chested Dotterel
+Charadrius mongolus_Lesser Sand-Plover
+Charadrius montanus_Mountain Plover
+Charadrius morinellus_Eurasian Dotterel
+Charadrius nivosus_Snowy Plover
+Charadrius peronii_Malaysian Plover
+Charadrius placidus_Long-billed Plover
+Charadrius semipalmatus_Semipalmated Plover
+Charadrius tricollaris_Three-banded Plover
+Charadrius veredus_Oriental Plover
+Charadrius vociferus_Killdeer
+Charadrius wilsonia_Wilson's Plover
+Charitospiza eucosma_Coal-crested Finch
+Charmosyna papou_West Papuan Lorikeet
+Chasiempis ibidis_Oahu Elepaio
+Chasiempis sandwichensis_Hawaii Elepaio
+Chasiempis sclateri_Kauai Elepaio
+Chauna chavaria_Northern Screamer
+Chauna torquata_Southern Screamer
+Chelidoptera tenebrosa_Swallow-winged Puffbird
+Chelidorhynx hypoxanthus_Yellow-bellied Fairy-Fantail
+Chenonetta jubata_Maned Duck
+Chersomanes albofasciata_Spike-heeled Lark
+Chersophilus duponti_Dupont's Lark
+Chionomesa fimbriata_Glittering-throated Emerald
+Chionomesa lactea_Sapphire-spangled Emerald
+Chiroxiphia boliviana_Yungas Manakin
+Chiroxiphia caudata_Swallow-tailed Manakin
+Chiroxiphia lanceolata_Lance-tailed Manakin
+Chiroxiphia linearis_Long-tailed Manakin
+Chiroxiphia pareola_Blue-backed Manakin
+Chlamydera maculata_Spotted Bowerbird
+Chlamydera nuchalis_Great Bowerbird
+Chlidonias albostriatus_Black-fronted Tern
+Chlidonias hybrida_Whiskered Tern
+Chlidonias leucopterus_White-winged Black Tern
+Chlidonias niger_Black Tern
+Chloephaga picta_Upland Goose
+Chlorestes candida_White-bellied Emerald
+Chlorestes cyanus_White-chinned Sapphire
+Chlorestes eliciae_Blue-throated Goldentail
+Chlorestes julie_Violet-bellied Hummingbird
+Chlorestes notata_Blue-chinned Sapphire
+Chloris chloris_European Greenfinch
+Chloris monguilloti_Vietnamese Greenfinch
+Chloris sinica_Oriental Greenfinch
+Chloris spinoides_Yellow-breasted Greenfinch
+Chloroceryle aenea_American Pygmy Kingfisher
+Chloroceryle amazona_Amazon Kingfisher
+Chloroceryle americana_Green Kingfisher
+Chloroceryle inda_Green-and-rufous Kingfisher
+Chlorochrysa phoenicotis_Glistening-green Tanager
+Chlorocichla flaviventris_Yellow-bellied Greenbul
+Chlorocichla laetissima_Joyful Greenbul
+Chlorocichla simplex_Simple Greenbul
+Chlorodrepanis flava_Oahu Amakihi
+Chlorodrepanis stejnegeri_Kauai Amakihi
+Chlorodrepanis virens_Hawaii Amakihi
+Chlorophanes spiza_Green Honeycreeper
+Chlorophonia callophrys_Golden-browed Chlorophonia
+Chlorophonia cyanea_Blue-naped Chlorophonia
+Chlorophonia cyanocephala_Golden-rumped Euphonia
+Chlorophonia elegantissima_Elegant Euphonia
+Chlorophonia flavirostris_Yellow-collared Chlorophonia
+Chlorophonia musica_Hispaniolan Euphonia
+Chlorophonia occipitalis_Blue-crowned Chlorophonia
+Chlorophonia pyrrhophrys_Chestnut-breasted Chlorophonia
+Chloropicus fuscescens_Cardinal Woodpecker
+Chloropicus goertae_African Gray Woodpecker
+Chloropicus griseocephalus_Olive Woodpecker
+Chloropicus namaquus_Bearded Woodpecker
+Chloropicus spodocephalus_Mountain Gray Woodpecker
+Chloropsis aurifrons_Golden-fronted Leafbird
+Chloropsis cochinchinensis_Javan Leafbird
+Chloropsis cyanopogon_Lesser Green Leafbird
+Chloropsis hardwickii_Orange-bellied Leafbird
+Chloropsis jerdoni_Jerdon's Leafbird
+Chloropsis sonnerati_Greater Green Leafbird
+Chlorornis riefferii_Grass-green Tanager
+Chlorospingus canigularis_Ashy-throated Chlorospingus
+Chlorospingus flavigularis_Yellow-throated Chlorospingus
+Chlorospingus flavopectus_Common Chlorospingus
+Chlorospingus pileatus_Sooty-capped Chlorospingus
+Chlorospingus semifuscus_Dusky Chlorospingus
+Chlorostilbon gibsoni_Red-billed Emerald
+Chlorostilbon lucidus_Glittering-bellied Emerald
+Chlorostilbon mellisugus_Blue-tailed Emerald
+Chlorothraupis carmioli_Carmiol's Tanager
+Chlorothraupis olivacea_Lemon-spectacled Tanager
+Chlorothraupis stolzmanni_Ochre-breasted Tanager
+Cholornis unicolor_Brown Parrotbill
+Chondestes grammacus_Lark Sparrow
+Chondrohierax uncinatus_Hook-billed Kite
+Chordeiles acutipennis_Lesser Nighthawk
+Chordeiles gundlachii_Antillean Nighthawk
+Chordeiles minor_Common Nighthawk
+Chordeiles nacunda_Nacunda Nighthawk
+Chordeiles pusillus_Least Nighthawk
+Chroicocephalus brunnicephalus_Brown-headed Gull
+Chroicocephalus cirrocephalus_Grey-hooded Gull
+Chroicocephalus genei_Slender-billed Gull
+Chroicocephalus maculipennis_Brown-hooded Gull
+Chroicocephalus novaehollandiae_Silver Gull
+Chroicocephalus philadelphia_Bonaparte's Gull
+Chroicocephalus ridibundus_Black-headed Gull
+Chroicocephalus serranus_Andean Gull
+Chrysococcyx basalis_Horsfield's Bronze-Cuckoo
+Chrysococcyx caprius_Dideric Cuckoo
+Chrysococcyx cupreus_African Emerald Cuckoo
+Chrysococcyx klaas_Klaas's Cuckoo
+Chrysococcyx lucidus_Shining Bronze-Cuckoo
+Chrysococcyx maculatus_Asian Emerald Cuckoo
+Chrysococcyx minutillus_Little Bronze-Cuckoo
+Chrysococcyx osculans_Black-eared Cuckoo
+Chrysococcyx xanthorhynchus_Violet Cuckoo
+Chrysocolaptes festivus_White-naped Woodpecker
+Chrysocolaptes guttacristatus_Greater Flameback
+Chrysolampis mosquitus_Ruby-topaz Hummingbird
+Chrysolophus amherstiae_Lady Amherst's Pheasant
+Chrysolophus pictus_Golden Pheasant
+Chrysomma altirostre_Jerdon's Babbler
+Chrysomma sinense_Yellow-eyed Babbler
+Chrysomus icterocephalus_Yellow-hooded Blackbird
+Chrysomus ruficapillus_Chestnut-capped Blackbird
+Chrysophlegma flavinucha_Greater Yellownape
+Chrysophlegma mentale_Checker-throated Woodpecker
+Chrysophlegma miniaceum_Banded Woodpecker
+Chrysothlypis chrysomelas_Black-and-yellow Tanager
+Chrysothlypis salmoni_Scarlet-and-white Tanager
+Chrysuronia oenone_Golden-tailed Sapphire
+Chrysuronia versicolor_Versicoloured Emerald
+Chunga burmeisteri_Black-legged Seriema
+Ciccaba albitarsis_Rufous-banded Owl
+Ciccaba huhula_Black-banded Owl
+Ciccaba nigrolineata_Black-and-white Owl
+Ciccaba virgata_Mottled Owl
+Cichladusa arquata_Collared Palm-Thrush
+Cichladusa guttata_Spotted Morning-Thrush
+Cichlocolaptes leucophrus_Pale-browed Treehunter
+Cichlopsis leucogenys_Rufous-brown Solitaire
+Cicinnurus magnificus_Magnificent Bird-of-Paradise
+Cicinnurus regius_King Bird-of-Paradise
+Cicinnurus respublica_Wilson's Bird-of-Paradise
+Ciconia ciconia_White Stork
+Ciconia nigra_Black Stork
+Cinclidium frontale_Blue-fronted Robin
+Cinclocerthia gutturalis_Grey Trembler
+Cinclodes albidiventris_Chestnut-winged Cinclodes
+Cinclodes albiventris_Cream-winged Cinclodes
+Cinclodes excelsior_Stout-billed Cinclodes
+Cinclodes fuscus_Buff-winged Cinclodes
+Cinclodes nigrofumosus_Seaside Cinclodes
+Cinclodes oustaleti_Grey-flanked Cinclodes
+Cinclodes pabsti_Long-tailed Cinclodes
+Cinclodes patagonicus_Dark-bellied Cinclodes
+Cincloramphus cruralis_Brown Songlark
+Cincloramphus macrurus_Papuan Grassbird
+Cincloramphus mathewsi_Rufous Songlark
+Cincloramphus timoriensis_Tawny Grassbird
+Cinclosoma ajax_Painted Quail-thrush
+Cinclosoma castaneothorax_Chestnut-breasted Quail-thrush
+Cinclosoma punctatum_Spotted Quail-thrush
+Cinclus cinclus_White-throated Dipper
+Cinclus mexicanus_American Dipper
+Cinclus pallasii_Brown Dipper
+Cinnycerthia fulva_Fulvous Wren
+Cinnycerthia olivascens_Sharpe's Wren
+Cinnycerthia peruana_Peruvian Wren
+Cinnycerthia unirufa_Rufous Wren
+Cinnyricinclus leucogaster_Violet-backed Starling
+Cinnyris afer_Greater Double-collared Sunbird
+Cinnyris asiaticus_Purple Sunbird
+Cinnyris bifasciatus_Purple-banded Sunbird
+Cinnyris chalybeus_Southern Double-collared Sunbird
+Cinnyris chloropygius_Olive-bellied Sunbird
+Cinnyris coccinigastrus_Splendid Sunbird
+Cinnyris cupreus_Copper Sunbird
+Cinnyris erythrocercus_Red-chested Sunbird
+Cinnyris fuscus_Dusky Sunbird
+Cinnyris gertrudis_Western Miombo Sunbird
+Cinnyris habessinicus_Shining Sunbird
+Cinnyris jugularis_Garden Sunbird
+Cinnyris lotenius_Loten's Sunbird
+Cinnyris mariquensis_Marico Sunbird
+Cinnyris mediocris_Eastern Double-collared Sunbird
+Cinnyris nectarinioides_Black-bellied Sunbird
+Cinnyris osea_Palestine Sunbird
+Cinnyris pulchellus_Beautiful Sunbird
+Cinnyris regius_Regal Sunbird
+Cinnyris reichenowi_Northern Double-collared Sunbird
+Cinnyris solaris_Flame-breasted Sunbird
+Cinnyris sovimanga_Souimanga Sunbird
+Cinnyris talatala_White-breasted Sunbird
+Cinnyris venustus_Variable Sunbird
+Circaetus gallicus_Short-toed Eagle
+Circus aeruginosus_Western Marsh Harrier
+Circus approximans_Swamp Harrier
+Circus buffoni_Long-winged Harrier
+Circus cyaneus_Hen Harrier
+Circus hudsonius_Northern Harrier
+Circus macrourus_Pallid Harrier
+Circus melanoleucos_Pied Harrier
+Circus pygargus_Montagu's Harrier
+Circus spilonotus_Eastern Marsh Harrier
+Cissa chinensis_Common Green-Magpie
+Cissa hypoleuca_Indochinese Green-Magpie
+Cissa jefferyi_Bornean Green-Magpie
+Cissopis leverianus_Magpie Tanager
+Cisticola aberrans_Rock-loving Cisticola
+Cisticola anonymus_Chattering Cisticola
+Cisticola aridulus_Desert Cisticola
+Cisticola ayresii_Wing-snapping Cisticola
+Cisticola brachypterus_Siffling Cisticola
+Cisticola cantans_Singing Cisticola
+Cisticola cherina_Madagascar Cisticola
+Cisticola chiniana_Rattling Cisticola
+Cisticola chubbi_Chubb's Cisticola
+Cisticola cinereolus_Ashy Cisticola
+Cisticola erythrops_Red-faced Cisticola
+Cisticola exilis_Golden-headed Cisticola
+Cisticola fulvicapilla_Piping Cisticola
+Cisticola haematocephalus_Coastal Cisticola
+Cisticola hunteri_Hunter's Cisticola
+Cisticola juncidis_Zitting Cisticola
+Cisticola lais_Wailing Cisticola
+Cisticola lateralis_Whistling Cisticola
+Cisticola marginatus_Winding Cisticola
+Cisticola natalensis_Croaking Cisticola
+Cisticola nigriloris_Black-lored Cisticola
+Cisticola njombe_Churring Cisticola
+Cisticola pipiens_Chirping Cisticola
+Cisticola robustus_Stout Cisticola
+Cisticola subruficapilla_Red-headed Cisticola
+Cisticola textrix_Cloud Cisticola
+Cisticola tinniens_Levaillant's Cisticola
+Cisticola woosnami_Trilling Cisticola
+Cistothorus apolinari_Apolinar's Wren
+Cistothorus palustris_Marsh Wren
+Cistothorus platensis_Grass Wren
+Cistothorus stellaris_Sedge Wren
+Clamator coromandus_Chestnut-winged Cuckoo
+Clamator glandarius_Great Spotted Cuckoo
+Clamator jacobinus_Pied Cuckoo
+Clamator levaillantii_Levaillant's Cuckoo
+Clanga clanga_Greater Spotted Eagle
+Clanga pomarina_Lesser Spotted Eagle
+Clangula hyemalis_Long-tailed Duck
+Claravis pretiosa_Blue Ground Dove
+Clibanornis dendrocolaptoides_Canebrake Groundcreeper
+Clibanornis erythrocephalus_Henna-hooded Foliage-gleaner
+Clibanornis rectirostris_Chestnut-capped Foliage-gleaner
+Clibanornis rubiginosus_Ruddy Foliage-gleaner
+Clibanornis rufipectus_Santa Marta Foliage-gleaner
+Climacteris picumnus_Brown Treecreeper
+Clytoctantes alixii_Recurve-billed Bushbird
+Clytolaema rubricauda_Brazilian Ruby
+Clytorhynchus vitiensis_Fiji Shrikebill
+Cnemoscopus rubrirostris_Grey-hooded Bush Tanager
+Cnemotriccus fuscatus_Fuscous Flycatcher
+Cnipodectes subbrunneus_Brownish Twistwing
+Coccopygia melanotis_Swee Waxbill
+Coccopygia quartinia_Yellow-bellied Waxbill
+Coccothraustes abeillei_Hooded Grosbeak
+Coccothraustes coccothraustes_Hawfinch
+Coccothraustes vespertinus_Evening Grosbeak
+Coccycua cinerea_Ash-coloured Cuckoo
+Coccycua minuta_Little Cuckoo
+Coccyzus americanus_Yellow-billed Cuckoo
+Coccyzus erythropthalmus_Black-billed Cuckoo
+Coccyzus euleri_Pearly-breasted Cuckoo
+Coccyzus longirostris_Hispaniolan Lizard-Cuckoo
+Coccyzus melacoryphus_Dark-billed Cuckoo
+Coccyzus merlini_Great Lizard-Cuckoo
+Coccyzus minor_Mangrove Cuckoo
+Coccyzus vieilloti_Puerto Rican Lizard-Cuckoo
+Cochlearius cochlearius_Boat-billed Heron
+Cochoa viridis_Green Cochoa
+Coeligena coeligena_Bronzy Inca
+Coeligena iris_Rainbow Starfrontlet
+Coeligena lutetiae_Buff-winged Starfrontlet
+Coeligena wilsoni_Brown Inca
+Coereba flaveola_Bananaquit
+Colaptes atricollis_Black-necked Woodpecker
+Colaptes auratus_Northern Flicker
+Colaptes auricularis_Grey-crowned Woodpecker
+Colaptes campestris_Campo Flicker
+Colaptes chrysoides_Gilded Flicker
+Colaptes fernandinae_Fernandina's Flicker
+Colaptes melanochloros_Green-barred Woodpecker
+Colaptes pitius_Chilean Flicker
+Colaptes punctigula_Spot-breasted Woodpecker
+Colaptes rivolii_Crimson-mantled Woodpecker
+Colaptes rubiginosus_Golden-olive Woodpecker
+Colaptes rupicola_Andean Flicker
+Colibri coruscans_Sparkling Violetear
+Colibri cyanotus_Lesser Violetear
+Colibri delphinae_Brown Violetear
+Colibri serrirostris_White-vented Violetear
+Colibri thalassinus_Mexican Violetear
+Colinus cristatus_Crested Bobwhite
+Colinus nigrogularis_Black-throated Bobwhite
+Colinus virginianus_Northern Bobwhite
+Colius colius_White-backed Mousebird
+Colius striatus_Speckled Mousebird
+Collocalia affinis_Plume-toed Swiftlet
+Colluricincla boweri_Bower's Shrikethrush
+Colluricincla harmonica_Grey Shrikethrush
+Colluricincla megarhyncha_Arafura Shrikethrush
+Colluricincla rufogaster_Rufous Shrikethrush
+Colonia colonus_Long-tailed Tyrant
+Colorhamphus parvirostris_Patagonian Tyrant
+Columba arquatrix_Rameron Pigeon
+Columba delegorguei_Delegorgue's Pigeon
+Columba guinea_Speckled Pigeon
+Columba iriditorques_Bronze-naped Pigeon
+Columba janthina_Japanese Woodpigeon
+Columba larvata_Lemon Dove
+Columba livia_Rock Dove
+Columba oenas_Stock Dove
+Columba palumbus_Common Woodpigeon
+Columba unicincta_Afep Pigeon
+Columba vitiensis_Metallic Pigeon
+Columbina buckleyi_Ecuadorian Ground Dove
+Columbina cruziana_Croaking Ground Dove
+Columbina cyanopis_Blue-eyed Ground Dove
+Columbina inca_Inca Dove
+Columbina minuta_Plain-breasted Ground Dove
+Columbina passerina_Common Ground Dove
+Columbina picui_Picui Ground Dove
+Columbina squammata_Scaled Dove
+Columbina talpacoti_Ruddy Ground Dove
+Compsothraupis loricata_Scarlet-throated Tanager
+Conioptilon mcilhennyi_Black-faced Cotinga
+Conirostrum albifrons_Capped Conebill
+Conirostrum bicolor_Bicoloured Conebill
+Conirostrum binghami_Giant Conebill
+Conirostrum cinereum_Cinereous Conebill
+Conirostrum leucogenys_White-eared Conebill
+Conirostrum margaritae_Pearly-breasted Conebill
+Conirostrum rufum_Rufous-browed Conebill
+Conirostrum sitticolor_Blue-backed Conebill
+Conirostrum speciosum_Chestnut-vented Conebill
+Conirostrum tamarugense_Tamarugo Conebill
+Conocephalus brevipennis_Short-winged Meadow Katydid
+Conocephalus fasciatus_Slender Meadow Katydid
+Conopias albovittatus_White-ringed Flycatcher
+Conopias cinchoneti_Lemon-browed Flycatcher
+Conopias parvus_Yellow-throated Flycatcher
+Conopias trivirgatus_Three-striped Flycatcher
+Conopophaga ardesiaca_Slaty Gnateater
+Conopophaga aurita_Chestnut-belted Gnateater
+Conopophaga castaneiceps_Chestnut-crowned Gnateater
+Conopophaga cearae_Ceara Gnateater
+Conopophaga lineata_Rufous Gnateater
+Conopophaga melanogaster_Black-bellied Gnateater
+Conopophaga melanops_Black-cheeked Gnateater
+Conopophaga peruviana_Ash-throated Gnateater
+Conopophila albogularis_Rufous-banded Honeyeater
+Conostoma aemodium_Great Parrotbill
+Conothraupis speculigera_Black-and-white Tanager
+Contopus caribaeus_Cuban Pewee
+Contopus cinereus_Southern Tropical Pewee
+Contopus cooperi_Olive-sided Flycatcher
+Contopus fumigatus_Smoke-coloured Pewee
+Contopus lugubris_Dark Pewee
+Contopus nigrescens_Blackish Pewee
+Contopus pertinax_Greater Pewee
+Contopus sordidulus_Western Wood-Pewee
+Contopus virens_Eastern Wood-Pewee
+Copsychus albiventris_Andaman Shama
+Copsychus albospecularis_Madagascar Magpie-Robin
+Copsychus cebuensis_Black Shama
+Copsychus fulicatus_Indian Robin
+Copsychus luzoniensis_White-browed Shama
+Copsychus malabaricus_White-rumped Shama
+Copsychus mindanensis_Philippine Magpie-Robin
+Copsychus niger_White-vented Shama
+Copsychus pyrropygus_Rufous-tailed Shama
+Copsychus saularis_Oriental Magpie-Robin
+Coracias abyssinicus_Abyssinian Roller
+Coracias benghalensis_Indian Roller
+Coracias caudatus_Lilac-breasted Roller
+Coracias garrulus_European Roller
+Coracina caesia_Grey Cuckooshrike
+Coracina cinerea_Madagascar Cuckooshrike
+Coracina lineata_Barred Cuckooshrike
+Coracina longicauda_Hooded Cuckooshrike
+Coracina macei_Large Cuckooshrike
+Coracina novaehollandiae_Black-faced Cuckooshrike
+Coracina papuensis_White-bellied Cuckooshrike
+Coracina pectoralis_White-breasted Cuckooshrike
+Coracina striata_Bar-bellied Cuckooshrike
+Coracopsis nigra_Lesser Vasa Parrot
+Coracopsis vasa_Greater Vasa Parrot
+Coragyps atratus_American Black Vulture
+Corapipo altera_White-ruffed Manakin
+Corapipo gutturalis_White-throated Manakin
+Corcorax melanorhamphos_White-winged Chough
+Cormobates leucophaea_White-throated Treecreeper
+Cormobates placens_Papuan Treecreeper
+Corthylio calendula_Ruby-crowned Kinglet
+Corvus albicollis_White-necked Raven
+Corvus albus_Pied Crow
+Corvus brachyrhynchos_American Crow
+Corvus capensis_Cape Crow
+Corvus corax_Common Raven
+Corvus cornix_Hooded Crow
+Corvus corone_Carrion Crow
+Corvus coronoides_Australian Raven
+Corvus cryptoleucus_Chihuahuan Raven
+Corvus dauuricus_Daurian Jackdaw
+Corvus enca_Slender-billed Crow
+Corvus florensis_Flores Crow
+Corvus frugilegus_Rook
+Corvus hawaiiensis_Hawaiian Crow
+Corvus imparatus_Tamaulipas Crow
+Corvus jamaicensis_Jamaican Crow
+Corvus leucognaphalus_White-necked Crow
+Corvus macrorhynchos_Large-billed Crow
+Corvus mellori_Little Raven
+Corvus monedula_Eurasian Jackdaw
+Corvus nasicus_Cuban Crow
+Corvus orru_Torresian Crow
+Corvus ossifragus_Fish Crow
+Corvus palmarum_Hispaniolan Palm-Crow
+Corvus rhipidurus_Fan-tailed Raven
+Corvus ruficollis_Brown-necked Raven
+Corvus sinaloae_Sinaloa Crow
+Corvus splendens_House Crow
+Corvus tasmanicus_Forest Raven
+Corvus tristis_Grey Crow
+Corvus typicus_Piping Crow
+Corvus validus_Long-billed Crow
+Corydon sumatranus_Dusky Broadbill
+Coryphaspiza melanotis_Black-masked Finch
+Coryphistera alaudina_Lark-like Brushrunner
+Coryphospingus cucullatus_Red-crested Finch
+Coryphospingus pileatus_Pileated Finch
+Corythaeola cristata_Great Blue Turaco
+Corythaixoides concolor_Gray Go-away-bird
+Corythaixoides leucogaster_White-bellied Go-away-bird
+Corythopis delalandi_Southern Antpipit
+Corythopis torquatus_Ringed Antpipit
+Corythornis cristatus_Malachite Kingfisher
+Coscoroba coscoroba_Coscoroba Swan
+Cossypha albicapillus_White-crowned Robin-Chat
+Cossypha anomala_Olive-flanked Robin-Chat
+Cossypha archeri_Archer's Robin-Chat
+Cossypha caffra_Cape Robin-Chat
+Cossypha cyanocampter_Blue-shouldered Robin-Chat
+Cossypha dichroa_Chorister Robin-Chat
+Cossypha heuglini_White-browed Robin-Chat
+Cossypha humeralis_White-throated Robin-Chat
+Cossypha natalensis_Red-capped Robin-Chat
+Cossypha niveicapilla_Snowy-crowned Robin-Chat
+Cossypha polioptera_Gray-winged Robin-Chat
+Cossypha semirufa_Rüppell's Robin-Chat
+Coturnicops noveboracensis_Yellow Rail
+Coturnix coromandelica_Rain Quail
+Coturnix coturnix_Common Quail
+Coturnix delegorguei_Harlequin Quail
+Coturnix japonica_Japanese Quail
+Coturnix pectoralis_Stubble Quail
+Coua caerulea_Blue Coua
+Coua coquereli_Coquerel's Coua
+Coua cristata_Crested Coua
+Coua gigas_Giant Coua
+Coua reynaudii_Red-fronted Coua
+Coua ruficeps_Red-capped Coua
+Coua serriana_Red-breasted Coua
+Cracticus cassicus_Hooded Butcherbird
+Cracticus nigrogularis_Pied Butcherbird
+Cracticus quoyi_Black Butcherbird
+Cracticus torquatus_Grey Butcherbird
+Cranioleuca albicapilla_Creamy-crested Spinetail
+Cranioleuca albiceps_Light-crowned Spinetail
+Cranioleuca antisiensis_Line-cheeked Spinetail
+Cranioleuca curtata_Ash-browed Spinetail
+Cranioleuca demissa_Tepui Spinetail
+Cranioleuca erythrops_Red-faced Spinetail
+Cranioleuca gutturata_Speckled Spinetail
+Cranioleuca hellmayri_Streak-capped Spinetail
+Cranioleuca marcapatae_Marcapata Spinetail
+Cranioleuca obsoleta_Olive Spinetail
+Cranioleuca pallida_Pallid Spinetail
+Cranioleuca pyrrhophia_Stripe-crowned Spinetail
+Cranioleuca semicinerea_Grey-headed Spinetail
+Cranioleuca subcristata_Crested Spinetail
+Cranioleuca vulpecula_Parker's Spinetail
+Cranioleuca vulpina_Rusty-backed Spinetail
+Crateroscelis murina_Rusty Mouse-Warbler
+Crateroscelis robusta_Mountain Mouse-Warbler
+Crax alberti_Blue-billed Curassow
+Crax alector_Black Curassow
+Crax fasciolata_Bare-faced Curassow
+Crax rubra_Great Curassow
+Creagrus furcatus_Swallow-tailed Gull
+Creatophora cinerea_Wattled Starling
+Crex crex_Corncrake
+Crinifer piscator_Western Plantain-eater
+Criniger barbatus_Western Bearded-Greenbul
+Criniger calurus_Red-tailed Greenbul
+Criniger chloronotus_Eastern Bearded-Greenbul
+Crithagra albogularis_White-throated Canary
+Crithagra atrogularis_Black-throated Canary
+Crithagra buchanani_Southern Grosbeak-Canary
+Crithagra dorsostriata_White-bellied Canary
+Crithagra flaviventris_Yellow Canary
+Crithagra gularis_Streaky-headed Seedeater
+Crithagra hyposticta_Southern Citril
+Crithagra menachensis_Yemen Serin
+Crithagra mozambica_Yellow-fronted Canary
+Crithagra reichenowi_Reichenow's Seedeater
+Crithagra scotops_Forest Canary
+Crithagra striolata_Streaky Seedeater
+Crithagra sulphurata_Brimstone Canary
+Crossleyia xanthophrys_Yellow-browed Oxylabes
+Crotophaga ani_Smooth-billed Ani
+Crotophaga major_Greater Ani
+Crotophaga sulcirostris_Groove-billed Ani
+Crypsirina temia_Racket-tailed Treepie
+Cryptillas victorini_Victorin's Warbler
+Cryptoleucopteryx plumbea_Plumbeous Hawk
+Cryptopezus nattereri_Speckle-breasted Antpitta
+Cryptopipo holochlora_Green Manakin
+Cryptospiza reichenovii_Red-faced Crimsonwing
+Cryptosylvicola randrianasoloi_Cryptic Warbler
+Crypturellus atrocapillus_Black-capped Tinamou
+Crypturellus bartletti_Bartlett's Tinamou
+Crypturellus boucardi_Slaty-breasted Tinamou
+Crypturellus cinereus_Cinereous Tinamou
+Crypturellus cinnamomeus_Thicket Tinamou
+Crypturellus duidae_Grey-legged Tinamou
+Crypturellus erythropus_Red-legged Tinamou
+Crypturellus noctivagus_Yellow-legged Tinamou
+Crypturellus obsoletus_Brown Tinamou
+Crypturellus parvirostris_Small-billed Tinamou
+Crypturellus soui_Little Tinamou
+Crypturellus strigulosus_Brazilian Tinamou
+Crypturellus tataupa_Tataupa Tinamou
+Crypturellus transfasciatus_Pale-browed Tinamou
+Crypturellus undulatus_Undulated Tinamou
+Crypturellus variegatus_Variegated Tinamou
+Cuculus canorus_Common Cuckoo
+Cuculus clamosus_Black Cuckoo
+Cuculus gularis_African Cuckoo
+Cuculus lepidus_Sunda Cuckoo
+Cuculus micropterus_Indian Cuckoo
+Cuculus optatus_Oriental Cuckoo
+Cuculus poliocephalus_Lesser Cuckoo
+Cuculus rochii_Madagascar Cuckoo
+Cuculus saturatus_Himalayan Cuckoo
+Cuculus solitarius_Red-chested Cuckoo
+Culicicapa ceylonensis_Grey-headed Canary-Flycatcher
+Culicicapa helianthea_Citrine Canary-Flycatcher
+Culicivora caudacuta_Sharp-tailed Tyrant
+Curaeus curaeus_Austral Blackbird
+Curruca boehmi_Banded Parisoma
+Curruca communis_Common Whitethroat
+Curruca conspicillata_Spectacled Warbler
+Curruca crassirostris_Eastern Orphean Warbler
+Curruca curruca_Lesser Whitethroat
+Curruca hortensis_Western Orphean Warbler
+Curruca iberiae_Western Subalpine Warbler
+Curruca melanocephala_Sardinian Warbler
+Curruca nisoria_Barred Warbler
+Curruca subcoerulea_Chestnut-vented Warbler
+Curruca undata_Dartford Warbler
+Cutia legalleni_Vietnamese Cutia
+Cutia nipalensis_Himalayan Cutia
+Cyanerpes caeruleus_Purple Honeycreeper
+Cyanerpes cyaneus_Red-legged Honeycreeper
+Cyanicterus cyanicterus_Blue-backed Tanager
+Cyanistes caeruleus_Eurasian Blue Tit
+Cyanistes cyanus_Azure Tit
+Cyanistes teneriffae_African Blue Tit
+Cyanocitta cristata_Blue Jay
+Cyanocitta stelleri_Steller's Jay
+Cyanocompsa parellina_Blue Bunting
+Cyanocorax affinis_Black-chested Jay
+Cyanocorax beecheii_Purplish-backed Jay
+Cyanocorax caeruleus_Azure Jay
+Cyanocorax cayanus_Cayenne Jay
+Cyanocorax chrysops_Plush-crested Jay
+Cyanocorax cristatellus_Curl-crested Jay
+Cyanocorax cyanomelas_Purplish Jay
+Cyanocorax cyanopogon_White-naped Jay
+Cyanocorax dickeyi_Tufted Jay
+Cyanocorax melanocyaneus_Bushy-crested Jay
+Cyanocorax mystacalis_White-tailed Jay
+Cyanocorax sanblasianus_San Blas Jay
+Cyanocorax violaceus_Violaceous Jay
+Cyanocorax yncas_Green Jay
+Cyanocorax yucatanicus_Yucatan Jay
+Cyanoderma ambiguum_Buff-chested Babbler
+Cyanoderma chrysaeum_Golden Babbler
+Cyanoderma erythropterum_Chestnut-winged Babbler
+Cyanoderma melanothorax_Crescent-chested Babbler
+Cyanoderma pyrrhops_Black-chinned Babbler
+Cyanoderma ruficeps_Rufous-capped Babbler
+Cyanoderma rufifrons_Rufous-fronted Babbler
+Cyanolanius madagascarinus_Madagascar Blue Vanga
+Cyanoliseus patagonus_Burrowing Parakeet
+Cyanoloxia brissonii_Ultramarine Grosbeak
+Cyanoloxia cyanoides_Blue-black Grosbeak
+Cyanoloxia glaucocaerulea_Glaucous-blue Grosbeak
+Cyanoloxia rothschildii_Amazonian Grosbeak
+Cyanolyca armillata_Black-collared Jay
+Cyanolyca cucullata_Azure-hooded Jay
+Cyanolyca mirabilis_White-throated Jay
+Cyanolyca nanus_Dwarf Jay
+Cyanolyca pulchra_Beautiful Jay
+Cyanolyca pumilo_Black-throated Jay
+Cyanolyca turcosa_Turquoise Jay
+Cyanolyca viridicyanus_White-collared Jay
+Cyanomitra cyanolaema_Blue-throated Brown Sunbird
+Cyanomitra olivacea_Olive Sunbird
+Cyanomitra veroxii_Mouse-coloured Sunbird
+Cyanomitra verticalis_Green-headed Sunbird
+Cyanopica cooki_Iberian Magpie
+Cyanopica cyanus_Azure-winged Magpie
+Cyanoptila cumatilis_Zappey's Flycatcher
+Cyanoptila cyanomelana_Blue-and-white Flycatcher
+Cyanoramphus novaezelandiae_Red-crowned Parakeet
+Cyclarhis gujanensis_Rufous-browed Peppershrike
+Cyclarhis nigrirostris_Black-billed Peppershrike
+Cygnus atratus_Black Swan
+Cygnus buccinator_Trumpeter Swan
+Cygnus columbianus_Bewick's Swan
+Cygnus cygnus_Whooper Swan
+Cygnus melancoryphus_Black-necked Swan
+Cygnus olor_Mute Swan
+Cymbilaimus lineatus_Fasciated Antshrike
+Cymbilaimus sanctaemariae_Bamboo Antshrike
+Cymbirhynchus macrorhynchos_Black-and-red Broadbill
+Cynanthus latirostris_Broad-billed Hummingbird
+Cyornis caerulatus_Sunda Blue Flycatcher
+Cyornis concretus_White-tailed Flycatcher
+Cyornis glaucicomans_Chinese Blue Flycatcher
+Cyornis hainanus_Hainan Blue Flycatcher
+Cyornis hoevelli_Blue-fronted Flycatcher
+Cyornis olivaceus_Fulvous-chested Jungle Flycatcher
+Cyornis omissus_Sulawesi Blue Flycatcher
+Cyornis pallidipes_White-bellied Blue Flycatcher
+Cyornis poliogenys_Pale-chinned Flycatcher
+Cyornis rubeculoides_Blue-throated Flycatcher
+Cyornis rufigastra_Mangrove Blue Flycatcher
+Cyornis sumatrensis_Indochinese Blue Flycatcher
+Cyornis superbus_Bornean Blue Flycatcher
+Cyornis tickelliae_Tickell's Blue Flycatcher
+Cyornis turcosus_Malaysian Blue Flycatcher
+Cyornis umbratilis_Grey-chested Jungle Flycatcher
+Cyornis unicolor_Pale Blue Flycatcher
+Cyornis whitei_Hill Blue Flycatcher
+Cyphorhinus arada_Musician Wren
+Cyphorhinus phaeocephalus_Song Wren
+Cyphorhinus thoracicus_Chestnut-breasted Wren
+Cypseloides niger_Black Swift
+Cypsiurus balasiensis_Asian Palm Swift
+Cypsiurus parvus_African Palm Swift
+Cypsnagra hirundinacea_White-rumped Tanager
+Cyrtonyx montezumae_Montezuma Quail
+Cyrtonyx ocellatus_Ocellated Quail
+Cyrtoxipha columbiana_Columbian Trig
+Dacelo gaudichaud_Rufous-bellied Kookaburra
+Dacelo leachii_Blue-winged Kookaburra
+Dacelo novaeguineae_Laughing Kookaburra
+Dacnis cayana_Blue Dacnis
+Dacnis flaviventer_Yellow-bellied Dacnis
+Dacnis lineata_Black-faced Dacnis
+Dacnis venusta_Scarlet-thighed Dacnis
+Dactylortyx thoracicus_Singing Quail
+Daphoenositta chrysoptera_Varied Sittella
+Daption capense_Cape Petrel
+Daptrius ater_Black Caracara
+Dasylophus cumingi_Scale-feathered Malkoha
+Dasyornis brachypterus_Eastern Bristlebird
+Dasyornis broadbenti_Rufous Bristlebird
+Dasyornis longirostris_Western Bristlebird
+Deconychura longicauda_Long-tailed Woodcreeper
+Delichon dasypus_Asian House Martin
+Delichon urbicum_Western House Martin
+Dendragapus fuliginosus_Sooty Grouse
+Dendragapus obscurus_Dusky Grouse
+Dendrexetastes rufigula_Cinnamon-throated Woodcreeper
+Dendrocincla anabatina_Tawny-winged Woodcreeper
+Dendrocincla fuliginosa_Plain-brown Woodcreeper
+Dendrocincla homochroa_Ruddy Woodcreeper
+Dendrocincla merula_White-chinned Woodcreeper
+Dendrocincla turdina_Plain-winged Woodcreeper
+Dendrocincla tyrannina_Tyrannine Woodcreeper
+Dendrocitta cinerascens_Bornean Treepie
+Dendrocitta formosae_Grey Treepie
+Dendrocitta leucogastra_White-bellied Treepie
+Dendrocitta vagabunda_Rufous Treepie
+Dendrocolaptes certhia_Amazonian Barred-Woodcreeper
+Dendrocolaptes picumnus_Black-banded Woodcreeper
+Dendrocolaptes platyrostris_Planalto Woodcreeper
+Dendrocolaptes sanctithomae_Northern Barred-Woodcreeper
+Dendrocopos analis_Freckle-breasted Woodpecker
+Dendrocopos darjellensis_Darjeeling Woodpecker
+Dendrocopos himalayensis_Himalayan Woodpecker
+Dendrocopos hyperythrus_Rufous-bellied Woodpecker
+Dendrocopos leucopterus_White-winged Woodpecker
+Dendrocopos leucotos_White-backed Woodpecker
+Dendrocopos macei_Fulvous-breasted Woodpecker
+Dendrocopos major_Great Spotted Woodpecker
+Dendrocopos syriacus_Syrian Woodpecker
+Dendrocoptes auriceps_Brown-fronted Woodpecker
+Dendrocoptes medius_Middle Spotted Woodpecker
+Dendrocygna arcuata_Wandering Whistling-Duck
+Dendrocygna autumnalis_Black-bellied Whistling-Duck
+Dendrocygna bicolor_Fulvous Whistling-Duck
+Dendrocygna eytoni_Plumed Whistling-Duck
+Dendrocygna javanica_Lesser Whistling-Duck
+Dendrocygna viduata_White-faced Whistling-Duck
+Dendroma erythroptera_Chestnut-winged Foliage-gleaner
+Dendroma rufa_Buff-fronted Foliage-gleaner
+Dendronanthus indicus_Forest Wagtail
+Dendroplex picus_Straight-billed Woodcreeper
+Dendrortyx barbatus_Bearded Wood-Partridge
+Dendrortyx leucophrys_Buffy-crowned Wood-Partridge
+Dendrortyx macroura_Long-tailed Wood-Partridge
+Deroptyus accipitrinus_Red-fan Parrot
+Dicaeum aeneum_Midget Flowerpecker
+Dicaeum agile_Thick-billed Flowerpecker
+Dicaeum australe_Red-keeled Flowerpecker
+Dicaeum chrysorrheum_Yellow-vented Flowerpecker
+Dicaeum concolor_Nilgiri Flowerpecker
+Dicaeum cruentatum_Scarlet-backed Flowerpecker
+Dicaeum erythrorhynchos_Pale-billed Flowerpecker
+Dicaeum hirundinaceum_Mistletoebird
+Dicaeum ignipectus_Fire-breasted Flowerpecker
+Dicaeum minullum_Plain Flowerpecker
+Dicaeum pygmaeum_Pygmy Flowerpecker
+Dicaeum trigonostigma_Orange-bellied Flowerpecker
+Dicaeum tristrami_Mottled Flowerpecker
+Dichrozona cincta_Banded Antbird
+Dicrurus adsimilis_Fork-tailed Drongo
+Dicrurus aeneus_Bronzed Drongo
+Dicrurus andamanensis_Andaman Drongo
+Dicrurus annectens_Crow-billed Drongo
+Dicrurus atripennis_Shining Drongo
+Dicrurus balicassius_Balicassiao
+Dicrurus bracteatus_Spangled Drongo
+Dicrurus caerulescens_White-bellied Drongo
+Dicrurus divaricatus_Glossy-backed Drongo
+Dicrurus forficatus_Crested Drongo
+Dicrurus hottentottus_Hair-crested Drongo
+Dicrurus leucophaeus_Ashy Drongo
+Dicrurus ludwigii_Square-tailed Drongo
+Dicrurus macrocercus_Black Drongo
+Dicrurus montanus_Sulawesi Drongo
+Dicrurus paradiseus_Greater Racket-tailed Drongo
+Dicrurus remifer_Lesser Racket-tailed Drongo
+Diglossa albilatera_White-sided Flowerpiercer
+Diglossa baritula_Cinnamon-bellied Flowerpiercer
+Diglossa brunneiventris_Black-throated Flowerpiercer
+Diglossa caerulescens_Bluish Flowerpiercer
+Diglossa cyanea_Masked Flowerpiercer
+Diglossa glauca_Deep-blue Flowerpiercer
+Diglossa gloriosissima_Chestnut-bellied Flowerpiercer
+Diglossa humeralis_Black Flowerpiercer
+Diglossa indigotica_Indigo Flowerpiercer
+Diglossa lafresnayii_Glossy Flowerpiercer
+Diglossa mystacalis_Moustached Flowerpiercer
+Diglossa plumbea_Slaty Flowerpiercer
+Diglossa sittoides_Rusty Flowerpiercer
+Dinemellia dinemelli_White-headed Buffalo-Weaver
+Dinopium benghalense_Black-rumped Flameback
+Dinopium javanense_Common Flameback
+Dinopium rafflesii_Olive-backed Woodpecker
+Diomedea exulans_Snowy Albatross
+Diopsittaca nobilis_Red-shouldered Macaw
+Diuca diuca_Diuca Finch
+Dives dives_Melodious Blackbird
+Dives warczewiczi_Scrub Blackbird
+Dog_Dog
+Dolichonyx oryzivorus_Bobolink
+Donacobius atricapilla_Black-capped Donacobius
+Donacospiza albifrons_Long-tailed Reed Finch
+Doryfera ludovicae_Green-fronted Lancebill
+Drepanis coccinea_Iiwi
+Drepanornis albertisi_Black-billed Sicklebill
+Dromas ardeola_Crab-Plover
+Dromococcyx pavoninus_Pavonine Cuckoo
+Dromococcyx phasianellus_Pheasant Cuckoo
+Drymodes brunneopygia_Southern Scrub-Robin
+Drymophila caudata_East Andean Antbird
+Drymophila devillei_Striated Antbird
+Drymophila ferruginea_Ferruginous Antbird
+Drymophila genei_Rufous-tailed Antbird
+Drymophila hellmayri_Santa Marta Antbird
+Drymophila klagesi_Klages's Antbird
+Drymophila malura_Dusky-tailed Antbird
+Drymophila ochropyga_Ochre-rumped Antbird
+Drymophila rubricollis_Bertoni's Antbird
+Drymophila squamata_Scaled Antbird
+Drymophila striaticeps_Streak-headed Antbird
+Drymornis bridgesii_Scimitar-billed Woodcreeper
+Dryobates affinis_Red-stained Woodpecker
+Dryobates albolarvatus_White-headed Woodpecker
+Dryobates arizonae_Arizona Woodpecker
+Dryobates borealis_Red-cockaded Woodpecker
+Dryobates callonotus_Scarlet-backed Woodpecker
+Dryobates cassini_Golden-collared Woodpecker
+Dryobates cathpharius_Crimson-naped Woodpecker
+Dryobates dignus_Yellow-vented Woodpecker
+Dryobates frontalis_Dot-fronted Woodpecker
+Dryobates fumigatus_Smoky-brown Woodpecker
+Dryobates kirkii_Red-rumped Woodpecker
+Dryobates lignarius_Striped Woodpecker
+Dryobates maculifrons_Yellow-eared Woodpecker
+Dryobates minor_Lesser Spotted Woodpecker
+Dryobates mixtus_Checkered Woodpecker
+Dryobates nigriceps_Bar-bellied Woodpecker
+Dryobates nuttallii_Nuttall's Woodpecker
+Dryobates passerinus_Little Woodpecker
+Dryobates pubescens_Downy Woodpecker
+Dryobates scalaris_Ladder-backed Woodpecker
+Dryobates spilogaster_White-spotted Woodpecker
+Dryobates stricklandi_Strickland's Woodpecker
+Dryobates villosus_Hairy Woodpecker
+Dryocopus javensis_White-bellied Woodpecker
+Dryocopus lineatus_Lineated Woodpecker
+Dryocopus martius_Black Woodpecker
+Dryocopus pileatus_Pileated Woodpecker
+Dryocopus schulzii_Black-bodied Woodpecker
+Dryolimnas cuvieri_White-throated Rail
+Dryophytes andersonii_Pine Barrens Treefrog
+Dryophytes arenicolor_Canyon Treefrog
+Dryophytes avivoca_Bird-voiced Treefrog
+Dryophytes chrysoscelis_Cope's Gray Treefrog
+Dryophytes cinereus_Green Treefrog
+Dryophytes femoralis_Pine Woods Treefrog
+Dryophytes gratiosus_Barking Treefrog
+Dryophytes squirellus_Squirrel Treefrog
+Dryophytes versicolor_Gray Treefrog
+Dryoscopus cubla_Black-backed Puffback
+Dryoscopus gambensis_Northern Puffback
+Dryotriorchis spectabilis_Congo Serpent-Eagle
+Dubusia castaneoventris_Chestnut-bellied Mountain Tanager
+Dubusia taeniata_Buff-breasted Mountain Tanager
+Ducula aenea_Green Imperial-Pigeon
+Ducula badia_Mountain Imperial-Pigeon
+Ducula basilica_Cinnamon-bellied Imperial-Pigeon
+Ducula bicolor_Pied Imperial-Pigeon
+Ducula concinna_Elegant Imperial-Pigeon
+Ducula lacernulata_Dark-backed Imperial-Pigeon
+Ducula latrans_Peale's Imperial-Pigeon
+Ducula pacifica_Pacific Imperial-Pigeon
+Ducula perspicillata_Spectacled Imperial-Pigeon
+Ducula pinon_Pinon's Imperial-Pigeon
+Ducula pistrinaria_Island Imperial-Pigeon
+Ducula poliocephala_Pink-bellied Imperial-Pigeon
+Ducula rubricera_Red-knobbed Imperial-Pigeon
+Ducula spilorrhoa_Torresian Imperial-Pigeon
+Ducula zoeae_Zoe's Imperial-Pigeon
+Dulus dominicus_Palmchat
+Dumetella carolinensis_Grey Catbird
+Dumetia atriceps_Dark-fronted Babbler
+Dumetia hyperythra_Tawny-bellied Babbler
+Dysithamnus leucostictus_White-streaked Antvireo
+Dysithamnus mentalis_Plain Antvireo
+Dysithamnus occidentalis_Bicoloured Antvireo
+Dysithamnus plumbeus_Plumbeous Antvireo
+Dysithamnus puncticeps_Spot-crowned Antvireo
+Dysithamnus stictothorax_Spot-breasted Antvireo
+Dysithamnus striaticeps_Streak-crowned Antvireo
+Dysithamnus xanthopterus_Rufous-backed Antvireo
+Eclectus roratus_Moluccan Eclectus
+Edolisoma montanum_Black-bellied Cicadabird
+Edolisoma tenuirostre_Common Cicadabird
+Egretta caerulea_Little Blue Heron
+Egretta eulophotes_Chinese Egret
+Egretta garzetta_Little Egret
+Egretta gularis_Western Reef-Heron
+Egretta novaehollandiae_White-faced Heron
+Egretta rufescens_Reddish Egret
+Egretta sacra_Pacific Reef-Heron
+Egretta thula_Snowy Egret
+Egretta tricolor_Tricoloured Heron
+Elachura formosa_Spotted Elachura
+Elaenia albiceps_White-crested Elaenia
+Elaenia brachyptera_Coopmans's Elaenia
+Elaenia chiriquensis_Lesser Elaenia
+Elaenia cristata_Plain-crested Elaenia
+Elaenia fallax_Greater Antillean Elaenia
+Elaenia flavogaster_Yellow-bellied Elaenia
+Elaenia frantzii_Mountain Elaenia
+Elaenia gigas_Mottle-backed Elaenia
+Elaenia martinica_Caribbean Elaenia
+Elaenia mesoleuca_Olivaceous Elaenia
+Elaenia obscura_Highland Elaenia
+Elaenia olivina_Tepui Elaenia
+Elaenia pallatangae_Sierran Elaenia
+Elaenia parvirostris_Small-billed Elaenia
+Elaenia ruficeps_Rufous-crowned Elaenia
+Elaenia sordida_Small-headed Elaenia
+Elaenia spectabilis_Large Elaenia
+Elaenia strepera_Slaty Elaenia
+Elanoides forficatus_Swallow-tailed Kite
+Elanus caeruleus_Black-winged Kite
+Elanus leucurus_White-tailed Kite
+Electron carinatum_Keel-billed Motmot
+Electron platyrhynchum_Broad-billed Motmot
+Eleoscytalopus indigoticus_White-breasted Tapaculo
+Eleothreptus anomalus_Sickle-winged Nightjar
+Eleutherodactylus planirostris_Greenhouse Frog
+Elliotomyia chionogaster_White-bellied Hummingbird
+Elminia albonotata_White-tailed Crested Flycatcher
+Elminia longicauda_African Blue Flycatcher
+Elseyornis melanops_Black-fronted Dotterel
+Emarginata sinuata_Sickle-winged Chat
+Emberiza aureola_Yellow-breasted Bunting
+Emberiza bruniceps_Red-headed Bunting
+Emberiza buchanani_Grey-necked Bunting
+Emberiza cabanisi_Cabanis's Bunting
+Emberiza caesia_Cretzschmar's Bunting
+Emberiza calandra_Corn Bunting
+Emberiza capensis_Cape Bunting
+Emberiza chrysophrys_Yellow-browed Bunting
+Emberiza cia_Rock Bunting
+Emberiza cineracea_Cinereous Bunting
+Emberiza cioides_Meadow Bunting
+Emberiza cirlus_Cirl Bunting
+Emberiza citrinella_Yellowhammer
+Emberiza elegans_Yellow-throated Bunting
+Emberiza flaviventris_Golden-breasted Bunting
+Emberiza fucata_Chestnut-eared Bunting
+Emberiza godlewskii_Godlewski's Bunting
+Emberiza hortulana_Ortolan Bunting
+Emberiza impetuani_Lark-like Bunting
+Emberiza lathami_Crested Bunting
+Emberiza leucocephalos_Pine Bunting
+Emberiza melanocephala_Black-headed Bunting
+Emberiza pallasi_Pallas's Reed Bunting
+Emberiza pusilla_Little Bunting
+Emberiza rustica_Rustic Bunting
+Emberiza sahari_House Bunting
+Emberiza schoeniclus_Common Reed Bunting
+Emberiza spodocephala_Black-faced Bunting
+Emberiza stewarti_White-capped Bunting
+Emberiza striolata_Striolated Bunting
+Emberiza sulphurata_Yellow Bunting
+Emberiza tahapisi_Cinnamon-breasted Bunting
+Emberiza tristrami_Tristram's Bunting
+Emberiza variabilis_Grey Bunting
+Emberiza yessoensis_Ochre-rumped Bunting
+Emberizoides herbicola_Wedge-tailed Grass-Finch
+Emberizoides ypiranganus_Lesser Grass-Finch
+Embernagra longicauda_Pale-throated Pampa-Finch
+Embernagra platensis_Great Pampa-Finch
+Eminia lepida_Grey-capped Warbler
+Empidonax affinis_Pine Flycatcher
+Empidonax albigularis_White-throated Flycatcher
+Empidonax alnorum_Alder Flycatcher
+Empidonax atriceps_Black-capped Flycatcher
+Empidonax difficilis_Western Flycatcher
+Empidonax flavescens_Yellowish Flycatcher
+Empidonax flaviventris_Yellow-bellied Flycatcher
+Empidonax fulvifrons_Buff-breasted Flycatcher
+Empidonax hammondii_Hammond's Flycatcher
+Empidonax minimus_Least Flycatcher
+Empidonax oberholseri_Dusky Flycatcher
+Empidonax occidentalis_Cordilleran Flycatcher
+Empidonax traillii_Willow Flycatcher
+Empidonax virescens_Acadian Flycatcher
+Empidonax wrightii_Grey Flycatcher
+Empidonomus aurantioatrocristatus_Crowned Slaty Flycatcher
+Empidonomus varius_Variegated Flycatcher
+Engine_Engine
+Enicognathus ferrugineus_Austral Parakeet
+Enicognathus leptorhynchus_Slender-billed Parakeet
+Enicurus leschenaulti_White-crowned Forktail
+Enicurus maculatus_Spotted Forktail
+Enicurus schistaceus_Slaty-backed Forktail
+Entomodestes coracinus_Black Solitaire
+Entomodestes leucotis_White-eared Solitaire
+Entomyzon cyanotis_Blue-faced Honeyeater
+Environmental_Environmental
+Eolophus roseicapilla_Galah
+Eophona migratoria_Yellow-billed Grosbeak
+Eophona personata_Japanese Grosbeak
+Eopsaltria australis_Eastern Yellow Robin
+Epimachus fastosus_Black Sicklebill
+Epimachus meyeri_Brown Sicklebill
+Epinecrophylla amazonica_Rio Madeira Stipplethroat
+Epinecrophylla erythrura_Rufous-tailed Stipplethroat
+Epinecrophylla fulviventris_Checker-throated Stipplethroat
+Epinecrophylla gutturalis_Brown-bellied Stipplethroat
+Epinecrophylla haematonota_Rufous-backed Stipplethroat
+Epinecrophylla leucophthalma_White-eyed Stipplethroat
+Epinecrophylla ornata_Ornate Stipplethroat
+Epinecrophylla spodionota_Foothill Stipplethroat
+Epthianura tricolor_Crimson Chat
+Eremomela gregalis_Yellow-rumped Eremomela
+Eremomela icteropygialis_Yellow-bellied Eremomela
+Eremomela pusilla_Senegal Eremomela
+Eremomela scotops_Greencap Eremomela
+Eremophila alpestris_Shore Lark
+Eremopterix griseus_Ashy-crowned Sparrow-Lark
+Eremopterix hova_Madagascar Lark
+Eremopterix nigriceps_Black-crowned Sparrow-Lark
+Erithacus rubecula_European Robin
+Erpornis zantholeuca_White-bellied Erpornis
+Erythrocercus holochlorus_Yellow Flycatcher
+Erythrogenys erythrocnemis_Black-necklaced Scimitar-Babbler
+Erythrogenys erythrogenys_Rusty-cheeked Scimitar-Babbler
+Erythrogenys gravivox_Black-streaked Scimitar-Babbler
+Erythrogenys hypoleucos_Large Scimitar-Babbler
+Erythrogenys mcclellandi_Spot-breasted Scimitar-Babbler
+Erythrogenys swinhoei_Grey-sided Scimitar-Babbler
+Erythropitta arquata_Blue-banded Pitta
+Erythropitta erythrogaster_Philippine Pitta
+Erythropitta granatina_Garnet Pitta
+Erythropitta macklotii_South Papuan Pitta
+Erythropitta rufiventris_North Moluccan Pitta
+Erythropitta ussheri_Black-crowned Pitta
+Erythrura trichroa_Blue-faced Parrotfinch
+Esacus magnirostris_Beach Thick-knee
+Esacus recurvirostris_Great Thick-knee
+Estrilda astrild_Common Waxbill
+Estrilda melpoda_Orange-cheeked Waxbill
+Estrilda nonnula_Black-crowned Waxbill
+Estrilda paludicola_Fawn-breasted Waxbill
+Estrilda troglodytes_Black-rumped Waxbill
+Eubucco bourcierii_Red-headed Barbet
+Eubucco richardsoni_Lemon-throated Barbet
+Euchrepomis callinota_Rufous-rumped Antwren
+Euchrepomis humeralis_Chestnut-shouldered Antwren
+Euchrepomis spodioptila_Ash-winged Antwren
+Eucometis penicillata_Grey-headed Tanager
+Eudocimus albus_White Ibis
+Eudromia elegans_Elegant Crested-Tinamou
+Eudynamys melanorhynchus_Black-billed Koel
+Eudynamys orientalis_Pacific Koel
+Eudynamys scolopaceus_Asian Koel
+Eudyptes chrysocome_Southern Rockhopper Penguin
+Eudyptula minor_Little Penguin
+Eugenes fulgens_Rivoli's Hummingbird
+Eugenes spectabilis_Talamanca Hummingbird
+Eugralla paradoxa_Ochre-flanked Tapaculo
+Eumomota superciliosa_Turquoise-browed Motmot
+Eumyias albicaudatus_Nilgiri Flycatcher
+Eumyias indigo_Indigo Flycatcher
+Eumyias panayensis_Turquoise Flycatcher
+Eumyias thalassinus_Verditer Flycatcher
+Eunemobius carolinus_Carolina Ground Cricket
+Eunemobius confusus_Confused Ground Cricket
+Euodice cantans_African Silverbill
+Euodice malabarica_Indian Silverbill
+Eupetes macrocerus_Malaysian Rail-babbler
+Eupetomena cirrochloris_Sombre Hummingbird
+Eupetomena macroura_Swallow-tailed Hummingbird
+Euphagus carolinus_Rusty Blackbird
+Euphagus cyanocephalus_Brewer's Blackbird
+Eupherusa eximia_Stripe-tailed Hummingbird
+Euphonia affinis_Scrub Euphonia
+Euphonia anneae_Tawny-capped Euphonia
+Euphonia cayennensis_Golden-sided Euphonia
+Euphonia chalybea_Green-throated Euphonia
+Euphonia chlorotica_Purple-throated Euphonia
+Euphonia chrysopasta_Golden-bellied Euphonia
+Euphonia concinna_Velvet-fronted Euphonia
+Euphonia finschi_Finsch's Euphonia
+Euphonia fulvicrissa_Fulvous-vented Euphonia
+Euphonia gouldi_Olive-backed Euphonia
+Euphonia hirundinacea_Yellow-throated Euphonia
+Euphonia imitans_Spot-crowned Euphonia
+Euphonia laniirostris_Thick-billed Euphonia
+Euphonia luteicapilla_Yellow-crowned Euphonia
+Euphonia mesochrysa_Bronze-green Euphonia
+Euphonia minuta_White-vented Euphonia
+Euphonia pectoralis_Chestnut-bellied Euphonia
+Euphonia plumbea_Plumbeous Euphonia
+Euphonia rufiventris_Rufous-bellied Euphonia
+Euphonia trinitatis_Trinidad Euphonia
+Euphonia violacea_Violaceous Euphonia
+Euphonia xanthogaster_Orange-bellied Euphonia
+Euplectes afer_Yellow-crowned Bishop
+Euplectes ardens_Red-collared Widowbird
+Euplectes capensis_Yellow Bishop
+Euplectes franciscanus_Northern Red Bishop
+Euplectes hordeaceus_Black-winged Bishop
+Euplectes orix_Southern Red Bishop
+Euplectes progne_Long-tailed Widowbird
+Eupodotis afra_Black Bustard
+Eupodotis afraoides_White-quilled Bustard
+Eupodotis caerulescens_Blue Bustard
+Eupodotis ruficrista_Red-crested Bustard
+Eupodotis senegalensis_White-bellied Bustard
+Eupodotis vigorsii_Karoo Bustard
+Eupsittula aurea_Peach-fronted Parakeet
+Eupsittula cactorum_Cactus Parakeet
+Eupsittula canicularis_Orange-fronted Parakeet
+Eupsittula nana_Olive-throated Parakeet
+Eupsittula pertinax_Brown-throated Parakeet
+Euptilotis neoxenus_Eared Quetzal
+Eurillas ansorgei_Ansorge's Greenbul
+Eurillas curvirostris_Plain Greenbul
+Eurillas latirostris_Yellow-whiskered Greenbul
+Eurillas virens_Little Greenbul
+Eurocephalus ruppelli_White-rumped Shrike
+Eurostopodus argus_Spotted Nightjar
+Eurostopodus mystacalis_White-throated Nightjar
+Eurylaimus javanicus_Banded Broadbill
+Eurylaimus ochromalus_Black-and-yellow Broadbill
+Eurypyga helias_Sunbittern
+Eurystomus glaucurus_Broad-billed Roller
+Eurystomus orientalis_Dollarbird
+Euscarthmus fulviceps_Fulvous-faced Scrub-Tyrant
+Euscarthmus meloryphus_Fulvous-crowned Scrub-Tyrant
+Euscarthmus rufomarginatus_Rufous-sided Scrub-Tyrant
+Eutoxeres aquila_White-tipped Sicklebill
+Falco amurensis_Amur Falcon
+Falco berigora_Brown Falcon
+Falco columbarius_Merlin
+Falco deiroleucus_Orange-breasted Falcon
+Falco femoralis_Aplomado Falcon
+Falco mexicanus_Prairie Falcon
+Falco naumanni_Lesser Kestrel
+Falco peregrinus_Peregrine Falcon
+Falco rufigularis_Bat Falcon
+Falco rusticolus_Gyr Falcon
+Falco sparverius_American Kestrel
+Falco subbuteo_Eurasian Hobby
+Falco tinnunculus_Common Kestrel
+Falco vespertinus_Red-footed Falcon
+Falculea palliata_Sickle-billed Vanga
+Falcunculus frontatus_Eastern Shrike-tit
+Ferminia cerverai_Zapata Wren
+Ficedula albicilla_Taiga Flycatcher
+Ficedula albicollis_Collared Flycatcher
+Ficedula basilanica_Little Slaty Flycatcher
+Ficedula dumetoria_Rufous-chested Flycatcher
+Ficedula elisae_Green-backed Flycatcher
+Ficedula erithacus_Slaty-backed Flycatcher
+Ficedula hodgsoni_Pygmy Flycatcher
+Ficedula hyperythra_Snowy-browed Flycatcher
+Ficedula hypoleuca_European Pied Flycatcher
+Ficedula mugimaki_Mugimaki Flycatcher
+Ficedula narcissina_Narcissus Flycatcher
+Ficedula nigrorufa_Black-and-orange Flycatcher
+Ficedula parva_Red-breasted Flycatcher
+Ficedula ruficauda_Rusty-tailed Flycatcher
+Ficedula semitorquata_Semicollared Flycatcher
+Ficedula strophiata_Rufous-gorgeted Flycatcher
+Ficedula subrubra_Kashmir Flycatcher
+Ficedula superciliaris_Ultramarine Flycatcher
+Ficedula tricolor_Slaty-blue Flycatcher
+Ficedula westermanni_Little Pied Flycatcher
+Ficedula zanthopygia_Yellow-rumped Flycatcher
+Fireworks_Fireworks
+Florisuga fusca_Black Jacobin
+Florisuga mellivora_White-necked Jacobin
+Fluvicola albiventer_Black-backed Water-Tyrant
+Fluvicola nengeta_Masked Water-Tyrant
+Fluvicola pica_Pied Water-Tyrant
+Formicarius analis_Black-faced Antthrush
+Formicarius colma_Rufous-capped Antthrush
+Formicarius moniliger_Mayan Antthrush
+Formicarius nigricapillus_Black-headed Antthrush
+Formicarius rufifrons_Rufous-fronted Antthrush
+Formicarius rufipectus_Rufous-breasted Antthrush
+Formicivora acutirostris_Marsh Antwren
+Formicivora erythronotos_Black-hooded Antwren
+Formicivora grantsaui_Sincora Antwren
+Formicivora grisea_Southern White-fringed Antwren
+Formicivora iheringi_Narrow-billed Antwren
+Formicivora melanogaster_Black-bellied Antwren
+Formicivora rufa_Rusty-backed Antwren
+Formicivora serrana_Serra Antwren
+Forpus coelestis_Pacific Parrotlet
+Forpus conspicillatus_Spectacled Parrotlet
+Forpus cyanopygius_Mexican Parrotlet
+Forpus modestus_Dusky-billed Parrotlet
+Forpus passerinus_Green-rumped Parrotlet
+Forpus xanthopterygius_Cobalt-rumped Parrotlet
+Foudia madagascariensis_Red Fody
+Foudia rubra_Mauritius Fody
+Foulehaio carunculatus_Eastern Wattled-Honeyeater
+Foulehaio procerior_Western Wattled-Honeyeater
+Francolinus francolinus_Black Francolin
+Francolinus pictus_Painted Francolin
+Francolinus pintadeanus_Chinese Francolin
+Fraseria caerulescens_Ashy Flycatcher
+Fraseria griseigularis_Grey-throated Tit-Flycatcher
+Fraseria ocreata_African Forest-Flycatcher
+Fraseria plumbea_Grey Tit-Flycatcher
+Fratercula arctica_Atlantic Puffin
+Frederickena fulva_Fulvous Antshrike
+Frederickena unduliger_Undulated Antshrike
+Frederickena viridis_Black-throated Antshrike
+Fregata andrewsi_Christmas Island Frigatebird
+Fregata ariel_Lesser Frigatebird
+Fregata magnificens_Magnificent Frigatebird
+Fregata minor_Great Frigatebird
+Fringilla coelebs_Common Chaffinch
+Fringilla montifringilla_Brambling
+Fulica alai_Hawaiian Coot
+Fulica americana_American Coot
+Fulica ardesiaca_Slate-coloured Coot
+Fulica armillata_Red-gartered Coot
+Fulica atra_Eurasian Coot
+Fulica cristata_Red-knobbed Coot
+Fulica gigantea_Giant Coot
+Fulica rufifrons_Red-fronted Coot
+Fulmarus glacialis_Northern Fulmar
+Fulvetta formosana_Taiwan Fulvetta
+Fulvetta ruficapilla_Spectacled Fulvetta
+Fulvetta vinipectus_White-browed Fulvetta
+Furnarius cristatus_Crested Hornero
+Furnarius figulus_Wing-banded Hornero
+Furnarius leucopus_Pale-legged Hornero
+Furnarius minor_Lesser Hornero
+Furnarius rufus_Rufous Hornero
+Galbalcyrhynchus leucotis_White-eared Jacamar
+Galbalcyrhynchus purusianus_Purus Jacamar
+Galbula albirostris_Yellow-billed Jacamar
+Galbula chalcothorax_Purplish Jacamar
+Galbula cyanescens_Bluish-fronted Jacamar
+Galbula cyanicollis_Blue-cheeked Jacamar
+Galbula dea_Paradise Jacamar
+Galbula galbula_Green-tailed Jacamar
+Galbula leucogastra_Bronzy Jacamar
+Galbula pastazae_Coppery-chested Jacamar
+Galbula ruficauda_Rufous-tailed Jacamar
+Galbula tombacea_White-chinned Jacamar
+Galerida cristata_Crested Lark
+Galerida deva_Tawny Lark
+Galerida magnirostris_Large-billed Lark
+Galerida malabarica_Malabar Lark
+Galerida theklae_Thekla's Lark
+Gallicrex cinerea_Watercock
+Gallinago andina_Puna Snipe
+Gallinago delicata_Wilson's Snipe
+Gallinago gallinago_Common Snipe
+Gallinago hardwickii_Latham's Snipe
+Gallinago imperialis_Imperial Snipe
+Gallinago jamesoni_Jameson's Snipe
+Gallinago magellanica_Magellanic Snipe
+Gallinago media_Great Snipe
+Gallinago megala_Swinhoe's Snipe
+Gallinago nobilis_Noble Snipe
+Gallinago paraguaiae_Pantanal Snipe
+Gallinago stenura_Pin-tailed Snipe
+Gallinago undulata_Giant Snipe
+Gallinula chloropus_Common Moorhen
+Gallinula galeata_American Moorhen
+Gallinula tenebrosa_Dusky Moorhen
+Gallirallus australis_Weka
+Gallirallus philippensis_Buff-banded Rail
+Gallirallus torquatus_Barred Rail
+Galloperdix bicalcarata_Sri Lanka Spurfowl
+Galloperdix spadicea_Red Spurfowl
+Gallus gallus_Red Junglefowl
+Gallus lafayettii_Sri Lanka Junglefowl
+Gallus sonneratii_Grey Junglefowl
+Gallus varius_Green Junglefowl
+Gampsonyx swainsonii_Pearl Kite
+Gampsorhynchus rufulus_White-hooded Babbler
+Gampsorhynchus torquatus_Collared Babbler
+Garrulax canorus_Chinese Hwamei
+Garrulax leucolophus_White-crested Laughingthrush
+Garrulax milleti_Black-hooded Laughingthrush
+Garrulax monileger_Lesser Necklaced Laughingthrush
+Garrulax palliatus_Sunda Laughingthrush
+Garrulax strepitans_White-necked Laughingthrush
+Garrulax taewanus_Taiwan Hwamei
+Garrulus glandarius_Eurasian Jay
+Garrulus lanceolatus_Black-headed Jay
+Garrulus lidthi_Lidth's Jay
+Gastrophryne carolinensis_Eastern Narrow-mouthed Toad
+Gastrophryne olivacea_Great Plains Narrow-mouthed Toad
+Gavia adamsii_White-billed Diver
+Gavia arctica_Black-throated Diver
+Gavia immer_Great Northern Diver
+Gavia pacifica_Pacific Diver
+Gavia stellata_Red-throated Diver
+Gavicalis fasciogularis_Mangrove Honeyeater
+Gavicalis virescens_Singing Honeyeater
+Gecinulus grantia_Pale-headed Woodpecker
+Gecinulus viridis_Bamboo Woodpecker
+Gelochelidon nilotica_Gull-billed Tern
+Geocerthia serrana_Striated Earthcreeper
+Geococcyx californianus_Greater Roadrunner
+Geococcyx velox_Lesser Roadrunner
+Geoffroyus geoffroyi_Red-cheeked Parrot
+Geoffroyus heteroclitus_Singing Parrot
+Geokichla citrina_Orange-headed Thrush
+Geokichla gurneyi_Orange Ground-Thrush
+Geokichla guttata_Spotted Ground-Thrush
+Geokichla peronii_Orange-banded Thrush
+Geokichla piaggiae_Abyssinian Ground-Thrush
+Geokichla sibirica_Siberian Thrush
+Geokichla spiloptera_Spot-winged Thrush
+Geopelia humeralis_Bar-shouldered Dove
+Geopelia placida_Peaceful Dove
+Geopelia striata_Zebra Dove
+Geositta antarctica_Short-billed Miner
+Geositta cunicularia_Common Miner
+Geositta punensis_Puna Miner
+Geositta rufipennis_Rufous-banded Miner
+Geositta tenuirostris_Slender-billed Miner
+Geospizopsis plebejus_Ash-breasted Sierra Finch
+Geospizopsis unicolor_Plumbeous Sierra Finch
+Geothlypis aequinoctialis_Masked Yellowthroat
+Geothlypis beldingi_Belding's Yellowthroat
+Geothlypis formosa_Kentucky Warbler
+Geothlypis nelsoni_Hooded Yellowthroat
+Geothlypis philadelphia_Mourning Warbler
+Geothlypis poliocephala_Grey-crowned Yellowthroat
+Geothlypis rostrata_Bahama Yellowthroat
+Geothlypis semiflava_Olive-crowned Yellowthroat
+Geothlypis speciosa_Black-polled Yellowthroat
+Geothlypis tolmiei_MacGillivray's Warbler
+Geothlypis trichas_Common Yellowthroat
+Geotrygon chrysia_Key West Quail-Dove
+Geotrygon montana_Ruddy Quail-Dove
+Geotrygon violacea_Violaceous Quail-Dove
+Geranoaetus albicaudatus_White-tailed Hawk
+Geranoaetus melanoleucus_Black-chested Buzzard-Eagle
+Geranoaetus polyosoma_Variable Hawk
+Geranospiza caerulescens_Crane Hawk
+Geronticus eremita_Northern Bald Ibis
+Gerygone chloronota_Green-backed Gerygone
+Gerygone flavolateralis_Fan-tailed Gerygone
+Gerygone fusca_Western Gerygone
+Gerygone igata_Grey Gerygone
+Gerygone levigaster_Mangrove Gerygone
+Gerygone magnirostris_Large-billed Gerygone
+Gerygone mouki_Brown Gerygone
+Gerygone olivacea_White-throated Gerygone
+Gerygone palpebrosa_Fairy Gerygone
+Gerygone sulphurea_Golden-bellied Gerygone
+Glareola lactea_Small Pratincole
+Glareola maldivarum_Oriental Pratincole
+Glareola pratincola_Collared Pratincole
+Glaucestrilda caerulescens_Lavender Waxbill
+Glaucidium bolivianum_Yungas Pygmy-Owl
+Glaucidium brasilianum_Ferruginous Pygmy-Owl
+Glaucidium capense_African Barred Owlet
+Glaucidium castanopterum_Javan Owlet
+Glaucidium castanotum_Chestnut-backed Owlet
+Glaucidium costaricanum_Costa Rican Pygmy-Owl
+Glaucidium cuculoides_Asian Barred Owlet
+Glaucidium gnoma_Northern Pygmy-Owl
+Glaucidium griseiceps_Central American Pygmy-Owl
+Glaucidium hardyi_Amazonian Pygmy-Owl
+Glaucidium jardinii_Andean Pygmy-Owl
+Glaucidium minutissimum_Least Pygmy-Owl
+Glaucidium nana_Austral Pygmy-Owl
+Glaucidium nubicola_Cloud-forest Pygmy-Owl
+Glaucidium palmarum_Colima Pygmy-Owl
+Glaucidium parkeri_Subtropical Pygmy-Owl
+Glaucidium passerinum_Eurasian Pygmy-Owl
+Glaucidium perlatum_Pearl-spotted Owlet
+Glaucidium peruanum_Peruvian Pygmy-Owl
+Glaucidium radiatum_Jungle Owlet
+Glaucidium sanchezi_Tamaulipas Pygmy-Owl
+Glaucidium siju_Cuban Pygmy-Owl
+Glaucidium tephronotum_Red-chested Owlet
+Glaucis dohrnii_Hook-billed Hermit
+Glaucis hirsutus_Rufous-breasted Hermit
+Gliciphila melanops_Tawny-crowned Honeyeater
+Glossopsitta concinna_Musk Lorikeet
+Glyphorynchus spirurus_Wedge-billed Woodcreeper
+Gnorimopsar chopi_Chopi Blackbird
+Gorsachius melanolophus_Malayan Night Heron
+Gracula indica_Southern Hill Myna
+Gracula ptilogenys_Sri Lanka Myna
+Gracula religiosa_Common Hill Myna
+Gracupica contra_Indian Pied Starling
+Gracupica nigricollis_Black-collared Starling
+Grallaria albigula_White-throated Antpitta
+Grallaria alleni_Moustached Antpitta
+Grallaria andicolus_Stripe-headed Antpitta
+Grallaria bangsi_Santa Marta Antpitta
+Grallaria blakei_Chestnut Antpitta
+Grallaria cajamarcae_Cajamarca Antpitta
+Grallaria capitalis_Bay Antpitta
+Grallaria carrikeri_Pale-billed Antpitta
+Grallaria dignissima_Ochre-striped Antpitta
+Grallaria erythroleuca_Red-and-white Antpitta
+Grallaria erythrotis_Rufous-faced Antpitta
+Grallaria flavotincta_Yellow-breasted Antpitta
+Grallaria gigantea_Giant Antpitta
+Grallaria gravesi_Chachapoyas Antpitta
+Grallaria griseonucha_Grey-naped Antpitta
+Grallaria guatimalensis_Scaled Antpitta
+Grallaria haplonota_Plain-backed Antpitta
+Grallaria hypoleuca_White-bellied Antpitta
+Grallaria kaestneri_Cundinamarca Antpitta
+Grallaria milleri_Brown-banded Antpitta
+Grallaria nuchalis_Chestnut-naped Antpitta
+Grallaria occabambae_Urubamba Antpitta
+Grallaria przewalskii_Rusty-tinged Antpitta
+Grallaria quitensis_Tawny Antpitta
+Grallaria ridgelyi_Jocotoco Antpitta
+Grallaria ruficapilla_Chestnut-crowned Antpitta
+Grallaria rufocinerea_Bicoloured Antpitta
+Grallaria rufula_Muisca Antpitta
+Grallaria saturata_Equatorial Antpitta
+Grallaria squamigera_Undulated Antpitta
+Grallaria urraoensis_Urrao Antpitta
+Grallaria varia_Variegated Antpitta
+Grallaria watkinsi_Watkins's Antpitta
+Grallaricula cucullata_Hooded Antpitta
+Grallaricula ferrugineipectus_Rusty-breasted Antpitta
+Grallaricula flavirostris_Ochre-breasted Antpitta
+Grallaricula leymebambae_Leymebamba Antpitta
+Grallaricula lineifrons_Crescent-faced Antpitta
+Grallaricula nana_Slate-crowned Antpitta
+Grallaricula ochraceifrons_Ochre-fronted Antpitta
+Grallaricula peruviana_Peruvian Antpitta
+Grallina cyanoleuca_Magpie-lark
+Grammatoptila striata_Striated Laughingthrush
+Granatellus pelzelni_Rose-breasted Chat
+Granatellus sallaei_Grey-throated Chat
+Granatellus venustus_Red-breasted Chat
+Granatina ianthinogaster_Purple Grenadier
+Grantiella picta_Painted Honeyeater
+Graydidascalus brachyurus_Short-tailed Parrot
+Grus americana_Whooping Crane
+Grus grus_Common Crane
+Grus japonensis_Red-crowned Crane
+Grus monacha_Hooded Crane
+Grus nigricollis_Black-necked Crane
+Gryllus assimilis_Gryllus assimilis
+Gryllus fultoni_Southern Wood Cricket
+Gryllus pennsylvanicus_Fall Field Cricket
+Gryllus rubens_Southeastern Field Cricket
+Guaruba guarouba_Golden Parakeet
+Gubernatrix cristata_Yellow Cardinal
+Gubernetes yetapa_Streamer-tailed Tyrant
+Guira guira_Guira Cuckoo
+Gun_Gun
+Guttera pucherani_Eastern Crested Guineafowl
+Gygis alba_White Tern
+Gymnasio nudipes_Puerto Rican Owl
+Gymnobucco bonapartei_Grey-throated Barbet
+Gymnobucco calvus_Naked-faced Barbet
+Gymnocichla nudiceps_Bare-crowned Antbird
+Gymnomystax mexicanus_Oriole Blackbird
+Gymnomyza brunneirostris_Duetting Giant-Honeyeater
+Gymnomyza samoensis_Mao
+Gymnopithys bicolor_Bicoloured Antbird
+Gymnopithys leucaspis_White-cheeked Antbird
+Gymnopithys rufigula_Rufous-throated Antbird
+Gymnorhina tibicen_Australian Magpie
+Gymnorhinus cyanocephalus_Pinyon Jay
+Gymnoris dentata_Sahel Bush Sparrow
+Gymnoris pyrgita_Yellow-spotted Bush Sparrow
+Gymnoris superciliaris_Yellow-throated Bush Sparrow
+Gymnoris xanthocollis_Yellow-throated Sparrow
+Gyps fulvus_Griffon Vulture
+Gyps himalayensis_Himalayan Griffon
+Gypsophila brevicaudata_Streaked Wren-Babbler
+Gypsophila rufipectus_Rusty-breasted Wren-Babbler
+Habia atrimaxillaris_Black-cheeked Ant-Tanager
+Habia cristata_Crested Ant-Tanager
+Habia fuscicauda_Red-throated Ant-Tanager
+Habia gutturalis_Sooty Ant-Tanager
+Habia rubica_Red-crowned Ant-Tanager
+Haematopus ater_Blackish Oystercatcher
+Haematopus bachmani_Black Oystercatcher
+Haematopus finschi_South Island Oystercatcher
+Haematopus fuliginosus_Sooty Oystercatcher
+Haematopus leucopodus_Magellanic Oystercatcher
+Haematopus longirostris_Pied Oystercatcher
+Haematopus ostralegus_Eurasian Oystercatcher
+Haematopus palliatus_American Oystercatcher
+Haematopus unicolor_Variable Oystercatcher
+Haematortyx sanguiniceps_Crimson-headed Partridge
+Haemorhous cassinii_Cassin's Finch
+Haemorhous mexicanus_House Finch
+Haemorhous purpureus_Purple Finch
+Hafferia fortis_Sooty Antbird
+Hafferia immaculata_Blue-lored Antbird
+Hafferia zeledoni_Zeledon's Antbird
+Halcyon albiventris_Brown-hooded Kingfisher
+Halcyon badia_Chocolate-backed Kingfisher
+Halcyon chelicuti_Striped Kingfisher
+Halcyon coromanda_Ruddy Kingfisher
+Halcyon gularis_Brown-breasted Kingfisher
+Halcyon leucocephala_Grey-headed Kingfisher
+Halcyon malimbica_Blue-breasted Kingfisher
+Halcyon pileata_Black-capped Kingfisher
+Halcyon senegalensis_Woodland Kingfisher
+Halcyon smyrnensis_White-throated Kingfisher
+Haliaeetus albicilla_White-tailed Eagle
+Haliaeetus humilis_Lesser Fish-Eagle
+Haliaeetus ichthyaetus_Gray-headed Fish-Eagle
+Haliaeetus leucocephalus_Bald Eagle
+Haliaeetus leucogaster_White-bellied Sea-Eagle
+Haliaeetus pelagicus_Steller's Sea-Eagle
+Haliaeetus vocifer_African Fish-Eagle
+Haliastur indus_Brahminy Kite
+Haliastur sphenurus_Whistling Kite
+Hapalocrex flaviventer_Yellow-breasted Crake
+Hapalopsittaca amazonina_Rusty-faced Parrot
+Hapalopsittaca fuertesi_Indigo-winged Parrot
+Hapaloptila castanea_White-faced Nunbird
+Haplophaedia aureliae_Greenish Puffleg
+Haplospiza unicolor_Uniform Finch
+Harpactes ardens_Philippine Trogon
+Harpactes diardii_Diard's Trogon
+Harpactes duvaucelii_Scarlet-rumped Trogon
+Harpactes erythrocephalus_Red-headed Trogon
+Harpactes fasciatus_Malabar Trogon
+Harpactes kasumba_Red-naped Trogon
+Harpactes oreskios_Orange-breasted Trogon
+Harpactes orrhophaeus_Cinnamon-rumped Trogon
+Harpactes wardi_Ward's Trogon
+Harpagus bidentatus_Double-toothed Kite
+Harpagus diodon_Rufous-thighed Kite
+Harpia harpyja_Harpy Eagle
+Harpyopsis novaeguineae_New Guinea Eagle
+Hedydipna collaris_Collared Sunbird
+Hedydipna metallica_Nile Valley Sunbird
+Hedydipna platura_Pygmy Sunbird
+Heliangelus amethysticollis_Amethyst-throated Sunangel
+Heliangelus exortis_Tourmaline Sunangel
+Heliangelus viola_Purple-throated Sunangel
+Helicolestes hamatus_Slender-billed Kite
+Heliobletus contaminatus_Sharp-billed Treehunter
+Heliodoxa jacula_Green-crowned Brilliant
+Heliodoxa leadbeateri_Violet-fronted Brilliant
+Heliodoxa rubinoides_Fawn-breasted Brilliant
+Heliomaster constantii_Plain-capped Starthroat
+Heliomaster longirostris_Long-billed Starthroat
+Heliornis fulica_Sungrebe
+Heliothryx auritus_Black-eared Fairy
+Hellmayrea gularis_White-browed Spinetail
+Helmitheros vermivorum_Worm-eating Warbler
+Helopsaltes certhiola_Pallas's Grasshopper Warbler
+Helopsaltes ochotensis_Middendorff's Grasshopper Warbler
+Helopsaltes pryeri_Marsh Grassbird
+Hemicircus canente_Heart-spotted Woodpecker
+Hemicircus concretus_Grey-and-buff Woodpecker
+Hemignathus wilsoni_Akiapolaau
+Hemiprocne comata_Whiskered Treeswift
+Hemiprocne coronata_Crested Treeswift
+Hemiprocne longipennis_Grey-rumped Treeswift
+Hemiprocne mystacea_Moustached Treeswift
+Hemipus hirundinaceus_Black-winged Flycatcher-shrike
+Hemipus picatus_Bar-winged Flycatcher-shrike
+Hemithraupis flavicollis_Yellow-backed Tanager
+Hemithraupis guira_Guira Tanager
+Hemithraupis ruficapilla_Rufous-headed Tanager
+Hemitriccus cinnamomeipectus_Cinnamon-breasted Tody-Tyrant
+Hemitriccus cohnhafti_Acre Tody-Tyrant
+Hemitriccus diops_Drab-breasted Pygmy-Tyrant
+Hemitriccus flammulatus_Flammulated Pygmy-Tyrant
+Hemitriccus furcatus_Fork-tailed Pygmy-Tyrant
+Hemitriccus granadensis_Black-throated Tody-Tyrant
+Hemitriccus griseipectus_White-bellied Tody-Tyrant
+Hemitriccus inornatus_Pelzeln's Tody-Tyrant
+Hemitriccus iohannis_Johannes's Tody-Tyrant
+Hemitriccus margaritaceiventer_Pearly-vented Tody-Tyrant
+Hemitriccus minimus_Zimmer's Tody-Tyrant
+Hemitriccus minor_Snethlage's Tody-Tyrant
+Hemitriccus nidipendulus_Hangnest Tody-Tyrant
+Hemitriccus obsoletus_Brown-breasted Pygmy-Tyrant
+Hemitriccus orbitatus_Eye-ringed Tody-Tyrant
+Hemitriccus rufigularis_Buff-throated Tody-Tyrant
+Hemitriccus spodiops_Yungas Tody-Tyrant
+Hemitriccus striaticollis_Stripe-necked Tody-Tyrant
+Hemitriccus zosterops_White-eyed Tody-Tyrant
+Hemixos castanonotus_Chestnut Bulbul
+Hemixos cinereus_Cinereous Bulbul
+Hemixos flavala_Ashy Bulbul
+Henicorhina anachoreta_Hermit Wood-Wren
+Henicorhina leucophrys_Grey-breasted Wood-Wren
+Henicorhina leucoptera_Bar-winged Wood-Wren
+Henicorhina leucosticta_White-breasted Wood-Wren
+Henicorhina negreti_Munchique Wood-Wren
+Herpetotheres cachinnans_Laughing Falcon
+Herpsilochmus atricapillus_Black-capped Antwren
+Herpsilochmus axillaris_Yellow-breasted Antwren
+Herpsilochmus dorsimaculatus_Spot-backed Antwren
+Herpsilochmus dugandi_Dugand's Antwren
+Herpsilochmus frater_Rusty-winged Antwren
+Herpsilochmus gentryi_Ancient Antwren
+Herpsilochmus longirostris_Large-billed Antwren
+Herpsilochmus motacilloides_Creamy-bellied Antwren
+Herpsilochmus parkeri_Ash-throated Antwren
+Herpsilochmus pectoralis_Pectoral Antwren
+Herpsilochmus pileatus_Bahia Antwren
+Herpsilochmus roraimae_Roraiman Antwren
+Herpsilochmus rufimarginatus_Rufous-margined Antwren
+Herpsilochmus sellowi_Caatinga Antwren
+Herpsilochmus stictocephalus_Todd's Antwren
+Herpsilochmus sticturus_Spot-tailed Antwren
+Heterocercus aurantiivertex_Orange-crowned Manakin
+Heterocercus flavivertex_Yellow-crowned Manakin
+Heterocercus linteatus_Flame-crowned Manakin
+Heteromyias albispecularis_Arfak Robin
+Heteromyias cinereifrons_Grey-headed Robin
+Heterophasia auricularis_White-eared Sibia
+Heterophasia capistrata_Rufous Sibia
+Heterophasia desgodinsi_Black-headed Sibia
+Heterophasia gracilis_Grey Sibia
+Heterophasia melanoleuca_Black-backed Sibia
+Heterophasia picaoides_Long-tailed Sibia
+Heterophasia pulchella_Beautiful Sibia
+Heterospingus xanthopygius_Scarlet-browed Tanager
+Hieraaetus pennatus_Booted Eagle
+Hierococcyx bocki_Dark Hawk-Cuckoo
+Hierococcyx fugax_Malaysian Hawk-Cuckoo
+Hierococcyx hyperythrus_Northern Hawk-Cuckoo
+Hierococcyx nisicolor_Hodgson's Hawk-Cuckoo
+Hierococcyx pectoralis_Philippine Hawk-Cuckoo
+Hierococcyx sparverioides_Large Hawk-Cuckoo
+Hierococcyx vagans_Moustached Hawk-Cuckoo
+Hierococcyx varius_Common Hawk-Cuckoo
+Himantopus himantopus_Black-winged Stilt
+Himantopus leucocephalus_Pied Stilt
+Himantopus mexicanus_Black-necked Stilt
+Himatione sanguinea_Apapane
+Hippolais icterina_Icterine Warbler
+Hippolais languida_Upcher's Warbler
+Hippolais olivetorum_Olive-tree Warbler
+Hippolais polyglotta_Melodious Warbler
+Hirundapus caudacutus_White-throated Needletail
+Hirundapus giganteus_Brown-backed Needletail
+Hirundinea ferruginea_Cliff Flycatcher
+Hirundo angolensis_Angola Swallow
+Hirundo neoxena_Welcome Swallow
+Hirundo rustica_Barn Swallow
+Hirundo smithii_Wire-tailed Swallow
+Hirundo tahitica_Pacific Swallow
+Histrionicus histrionicus_Harlequin Duck
+Histurgops ruficauda_Rufous-tailed Weaver
+Horizocerus albocristatus_Western Long-tailed Hornbill
+Horornis acanthizoides_Yellowish-bellied Bush Warbler
+Horornis annae_Palau Bush Warbler
+Horornis brunnescens_Hume's Bush Warbler
+Horornis canturians_Manchurian Bush Warbler
+Horornis diphone_Japanese Bush Warbler
+Horornis flavolivaceus_Aberrant Bush Warbler
+Horornis fortipes_Brownish-flanked Bush Warbler
+Horornis ruficapilla_Fiji Bush Warbler
+Horornis seebohmi_Philippine Bush Warbler
+Horornis vulcanius_Sunda Bush Warbler
+Human non-vocal_Human non-vocal
+Human vocal_Human vocal
+Human whistle_Human whistle
+Hydrobates castro_Band-rumped Storm-Petrel
+Hydrobates leucorhous_Leach's Storm-Petrel
+Hydrobates monorhis_Swinhoe's Storm-Petrel
+Hydrobates pelagicus_European Storm-Petrel
+Hydrobates tristrami_Tristram's Storm-Petrel
+Hydrocoloeus minutus_Little Gull
+Hydrophasianus chirurgus_Pheasant-tailed Jacana
+Hydroprogne caspia_Caspian Tern
+Hydropsalis cayennensis_White-tailed Nightjar
+Hydropsalis climacocerca_Ladder-tailed Nightjar
+Hydropsalis maculicaudus_Spot-tailed Nightjar
+Hydropsalis torquata_Scissor-tailed Nightjar
+Hydrornis baudii_Blue-headed Pitta
+Hydrornis caeruleus_Giant Pitta
+Hydrornis cyaneus_Blue Pitta
+Hydrornis elliotii_Bar-bellied Pitta
+Hydrornis irena_Malayan Banded-Pitta
+Hydrornis nipalensis_Blue-naped Pitta
+Hydrornis oatesi_Rusty-naped Pitta
+Hydrornis schwaneri_Bornean Banded-Pitta
+Hydrornis soror_Blue-rumped Pitta
+Hylacola cauta_Shy Heathwren
+Hylexetastes perrotii_Red-billed Woodcreeper
+Hylexetastes stresemanni_Bar-bellied Woodcreeper
+Hylexetastes uniformis_Uniform Woodcreeper
+Hylia prasina_Green Hylia
+Hyliola regilla_Pacific Chorus Frog
+Hylocharis chrysura_Gilded Hummingbird
+Hylocharis sapphirina_Rufous-throated Sapphire
+Hylocichla mustelina_Wood Thrush
+Hylomanes momotula_Tody Motmot
+Hylopezus macularius_Spotted Antpitta
+Hylopezus ochroleucus_White-browed Antpitta
+Hylopezus paraensis_Snethlage's Antpitta
+Hylopezus perspicillatus_Streak-chested Antpitta
+Hylopezus whittakeri_Alta Floresta Antpitta
+Hylophilus amaurocephalus_Grey-eyed Greenlet
+Hylophilus brunneiceps_Brown-headed Greenlet
+Hylophilus flavipes_Scrub Greenlet
+Hylophilus olivaceus_Olivaceous Greenlet
+Hylophilus pectoralis_Ashy-headed Greenlet
+Hylophilus poicilotis_Rufous-crowned Greenlet
+Hylophilus semicinereus_Grey-chested Greenlet
+Hylophilus thoracicus_Lemon-chested Greenlet
+Hylophylax naevioides_Spotted Antbird
+Hylophylax naevius_Spot-backed Antbird
+Hylophylax punctulatus_Dot-backed Antbird
+Hylorchilus navai_Nava's Wren
+Hylorchilus sumichrasti_Sumichrast's Wren
+Hymenops perspicillatus_Spectacled Tyrant
+Hypargos niveoguttatus_Peters's Twinspot
+Hypergerus atriceps_Oriole Warbler
+Hypnelus ruficollis_Russet-throated Puffbird
+Hypocnemis cantator_Guianan Warbling-Antbird
+Hypocnemis flavescens_Imeri Warbling-Antbird
+Hypocnemis hypoxantha_Yellow-browed Antbird
+Hypocnemis ochrogyna_Rondonia Warbling-Antbird
+Hypocnemis peruviana_Peruvian Warbling-Antbird
+Hypocnemis striata_Spix's Warbling-Antbird
+Hypocnemis subflava_Yellow-breasted Warbling-Antbird
+Hypocnemoides maculicauda_Band-tailed Antbird
+Hypocnemoides melanopogon_Black-chinned Antbird
+Hypocolius ampelinus_Hypocolius
+Hypoedaleus guttatus_Spot-backed Antshrike
+Hypopyrrhus pyrohypogaster_Red-bellied Grackle
+Hypothymis azurea_Black-naped Monarch
+Hypothymis puella_Pale-blue Monarch
+Hypsipetes amaurotis_Brown-eared Bulbul
+Hypsipetes everetti_Yellowish Bulbul
+Hypsipetes ganeesa_Square-tailed Bulbul
+Hypsipetes leucocephalus_Black Bulbul
+Hypsipetes madagascariensis_Malagasy Bulbul
+Hypsipetes olivaceus_Mauritius Bulbul
+Hypsipetes philippinus_Philippine Bulbul
+Ianthocincla maxima_Giant Laughingthrush
+Ianthocincla ocellata_Spotted Laughingthrush
+Ianthocincla rufogularis_Rufous-chinned Laughingthrush
+Ibidorhyncha struthersii_Ibisbill
+Ibycter americanus_Red-throated Caracara
+Ichthyaetus audouinii_Audouin's Gull
+Ichthyaetus melanocephalus_Mediterranean Gull
+Icteria virens_Yellow-breasted Chat
+Icterus abeillei_Black-backed Oriole
+Icterus auratus_Orange Oriole
+Icterus auricapillus_Orange-crowned Oriole
+Icterus bullockii_Bullock's Oriole
+Icterus cayanensis_Epaulet Oriole
+Icterus chrysater_Yellow-backed Oriole
+Icterus croconotus_Orange-backed Troupial
+Icterus cucullatus_Hooded Oriole
+Icterus galbula_Baltimore Oriole
+Icterus graceannae_White-edged Oriole
+Icterus graduacauda_Audubon's Oriole
+Icterus gularis_Altamira Oriole
+Icterus icterus_Venezuelan Troupial
+Icterus jamacaii_Campo Troupial
+Icterus leucopteryx_Jamaican Oriole
+Icterus mesomelas_Yellow-tailed Oriole
+Icterus nigrogularis_Yellow Oriole
+Icterus parisorum_Scott's Oriole
+Icterus pectoralis_Spot-breasted Oriole
+Icterus portoricensis_Puerto Rican Oriole
+Icterus prosthemelas_Black-cowled Oriole
+Icterus pustulatus_Streak-backed Oriole
+Icterus pyrrhopterus_Variable Oriole
+Icterus spurius_Orchard Oriole
+Icterus wagleri_Black-vented Oriole
+Ictinaetus malaiensis_Black Eagle
+Ictinia mississippiensis_Mississippi Kite
+Ictinia plumbea_Plumbeous Kite
+Iduna caligata_Booted Warbler
+Iduna natalensis_African Yellow-Warbler
+Iduna opaca_Western Olivaceous Warbler
+Iduna pallida_Eastern Olivaceous Warbler
+Iduna rama_Sykes's Warbler
+Iduna similis_Mountain Yellow-Warbler
+Ifrita kowaldi_Blue-capped Ifrita
+Ilicura militaris_Pin-tailed Manakin
+Illadopsis albipectus_Scaly-breasted Illadopsis
+Illadopsis cleaveri_Blackcap Illadopsis
+Illadopsis fulvescens_Brown Illadopsis
+Illadopsis puveli_Puvel's Illadopsis
+Illadopsis pyrrhoptera_Mountain Illadopsis
+Illadopsis rufipennis_Pale-breasted Illadopsis
+Incaspiza laeta_Buff-bridled Inca-Finch
+Incaspiza ortizi_Grey-winged Inca-Finch
+Incaspiza personata_Rufous-backed Inca-Finch
+Incilius valliceps_Gulf Coast Toad
+Indicator indicator_Greater Honeyguide
+Indicator minor_Lesser Honeyguide
+Indicator variegatus_Scaly-throated Honeyguide
+Inezia caudata_Pale-tipped Tyrannulet
+Inezia inornata_Plain Tyrannulet
+Inezia subflava_Amazonian Tyrannulet
+Inezia tenuirostris_Slender-billed Tyrannulet
+Iodopleura isabellae_White-browed Purpletuft
+Iodopleura pipra_Buff-throated Purpletuft
+Iole crypta_Buff-vented Bulbul
+Iole indica_Yellow-browed Bulbul
+Iole propinqua_Grey-eyed Bulbul
+Iole viridescens_Olive Bulbul
+Irania gutturalis_White-throated Robin
+Irena cyanogastra_Philippine Fairy-bluebird
+Irena puella_Asian Fairy-bluebird
+Iridosornis analis_Yellow-throated Tanager
+Iridosornis porphyrocephalus_Purplish-mantled Tanager
+Iridosornis rufivertex_Golden-crowned Tanager
+Isleria guttata_Rufous-bellied Antwren
+Isleria hauxwelli_Plain-throated Antwren
+Ithaginis cruentus_Blood Pheasant
+Ixobrychus cinnamomeus_Cinnamon Bittern
+Ixobrychus dubius_Black-backed Bittern
+Ixobrychus eurhythmus_Schrenck's Bittern
+Ixobrychus exilis_Least Bittern
+Ixobrychus flavicollis_Black Bittern
+Ixobrychus involucris_Stripe-backed Bittern
+Ixobrychus minutus_Little Bittern
+Ixobrychus sinensis_Yellow Bittern
+Ixonotus guttatus_Spotted Greenbul
+Ixoreus naevius_Varied Thrush
+Ixos malaccensis_Streaked Bulbul
+Ixos mcclellandii_Mountain Bulbul
+Ixothraupis guttata_Speckled Tanager
+Ixothraupis punctata_Spotted Tanager
+Ixothraupis rufigula_Rufous-throated Tanager
+Ixothraupis varia_Dotted Tanager
+Jabiru mycteria_Jabiru
+Jacamaralcyon tridactyla_Three-toed Jacamar
+Jacamerops aureus_Great Jacamar
+Jacana jacana_Wattled Jacana
+Jacana spinosa_Northern Jacana
+Junco hyemalis_Dark-eyed Junco
+Junco phaeonotus_Yellow-eyed Junco
+Jynx ruficollis_Rufous-necked Wryneck
+Jynx torquilla_Eurasian Wryneck
+Kakamega poliothorax_Grey-chested Babbler
+Kaupifalco monogrammicus_Lizard Buzzard
+Kenopia striata_Striped Wren-Babbler
+Ketupa blakistoni_Blakiston's Fish-Owl
+Ketupa ketupu_Buffy Fish-Owl
+Ketupa zeylonensis_Brown Fish-Owl
+Klais guimeti_Violet-headed Hummingbird
+Kleinothraupis atropileus_Black-capped Hemispingus
+Kleinothraupis parodii_Parodi's Hemispingus
+Knipolegus aterrimus_White-winged Black-Tyrant
+Knipolegus hudsoni_Hudson's Black-Tyrant
+Knipolegus orenocensis_Riverside Tyrant
+Knipolegus poecilurus_Rufous-tailed Tyrant
+Kurochkinegramma hypogrammicum_Purple-naped Spiderhunter
+Lacedo pulchella_Banded Kingfisher
+Lafresnaya lafresnayi_Mountain Velvetbreast
+Lagonosticta rhodopareia_Jameson's Firefinch
+Lagonosticta rubricata_African Firefinch
+Lagonosticta senegala_Red-billed Firefinch
+Lagopus lagopus_Red Grouse/Willow Grouse
+Lagopus leucura_White-tailed Ptarmigan
+Lagopus muta_Rock Ptarmigan
+Lalage aurea_Rufous-bellied Triller
+Lalage fimbriata_Lesser Cuckooshrike
+Lalage leucomela_Varied Triller
+Lalage leucopyga_Long-tailed Triller
+Lalage maculosa_Polynesian Triller
+Lalage melanoptera_Black-headed Cuckooshrike
+Lalage melaschistos_Black-winged Cuckooshrike
+Lalage nigra_Pied Triller
+Lalage tricolor_White-winged Triller
+Lampornis amethystinus_Amethyst-throated Mountain-gem
+Lampornis clemenciae_Blue-throated Mountain-gem
+Lampornis sybillae_Green-breasted Mountain-gem
+Lampornis viridipallens_Green-throated Mountain-gem
+Lampropsar tanagrinus_Velvet-fronted Grackle
+Lamprospiza melanoleuca_Red-billed Pied Tanager
+Lamprotornis australis_Burchell's Starling
+Lamprotornis bicolor_African Pied Starling
+Lamprotornis caudatus_Long-tailed Glossy Starling
+Lamprotornis chalybaeus_Greater Blue-eared Starling
+Lamprotornis chloropterus_Lesser Blue-eared Starling
+Lamprotornis hildebrandti_Hildebrandt's Starling
+Lamprotornis mevesii_Meves's Starling
+Lamprotornis nitens_Cape Starling
+Lamprotornis purpuroptera_Rüppell's Starling
+Lamprotornis splendidus_Splendid Starling
+Lamprotornis superbus_Superb Starling
+Lamprotornis unicolor_Ashy Starling
+Laniarius aethiopicus_Ethiopian Boubou
+Laniarius atrococcineus_Crimson-breasted Gonolek
+Laniarius atroflavus_Yellow-breasted Boubou
+Laniarius barbarus_Yellow-crowned Gonolek
+Laniarius bicolor_Gabon Boubou
+Laniarius erythrogaster_Black-headed Gonolek
+Laniarius ferrugineus_Southern Boubou
+Laniarius fuelleborni_Fülleborn's Boubou
+Laniarius funebris_Slate-coloured Boubou
+Laniarius luehderi_Lühder's Bushshrike
+Laniarius major_Tropical Boubou
+Laniarius mufumbiri_Papyrus Gonolek
+Laniarius poensis_Western Boubou
+Laniarius sublacteus_Zanzibar Boubou
+Laniisoma elegans_Brazilian Laniisoma
+Lanio aurantius_Black-throated Shrike-Tanager
+Lanio fulvus_Fulvous Shrike-Tanager
+Lanio leucothorax_White-throated Shrike-Tanager
+Lanio versicolor_White-winged Shrike-Tanager
+Laniocera hypopyrra_Cinereous Mourner
+Laniocera rufescens_Speckled Mourner
+Lanius borealis_Northern Shrike
+Lanius bucephalus_Bull-headed Shrike
+Lanius cabanisi_Long-tailed Fiscal
+Lanius collaris_Southern Fiscal
+Lanius collurio_Red-backed Shrike
+Lanius collurioides_Burmese Shrike
+Lanius corvinus_Yellow-billed Shrike
+Lanius cristatus_Brown Shrike
+Lanius excubitor_Great Grey Shrike
+Lanius humeralis_Northern Fiscal
+Lanius isabellinus_Isabelline Shrike
+Lanius ludovicianus_Loggerhead Shrike
+Lanius meridionalis_Iberian Grey Shrike
+Lanius minor_Lesser Grey Shrike
+Lanius nubicus_Masked Shrike
+Lanius phoenicuroides_Turkestan Shrike
+Lanius schach_Long-tailed Shrike
+Lanius senator_Woodchat Shrike
+Lanius sphenocercus_Chinese Grey Shrike
+Lanius tephronotus_Grey-backed Shrike
+Lanius tigrinus_Tiger Shrike
+Lanius vittatus_Bay-backed Shrike
+Larosterna inca_Inca Tern
+Larus argentatus_Herring Gull
+Larus belcheri_Belcher's Gull
+Larus brachyrhynchus_Short-billed Gull
+Larus cachinnans_Caspian Gull
+Larus californicus_California Gull
+Larus canus_Common Gull
+Larus crassirostris_Black-tailed Gull
+Larus delawarensis_Ring-billed Gull
+Larus dominicanus_Kelp Gull
+Larus fuscus_Lesser Black-backed Gull
+Larus glaucescens_Glaucous-winged Gull
+Larus glaucoides_Iceland Gull
+Larus heermanni_Heermann's Gull
+Larus hyperboreus_Glaucous Gull
+Larus livens_Yellow-footed Gull
+Larus marinus_Great Black-backed Gull
+Larus michahellis_Yellow-legged Gull
+Larus occidentalis_Western Gull
+Larus schistisagus_Slaty-backed Gull
+Larvivora akahige_Japanese Robin
+Larvivora brunnea_Indian Blue Robin
+Larvivora cyane_Siberian Blue Robin
+Larvivora komadori_Ryukyu Robin
+Larvivora sibilans_Rufous-tailed Robin
+Laterallus albigularis_White-throated Crake
+Laterallus exilis_Grey-breasted Crake
+Laterallus jamaicensis_Black Rail
+Laterallus leucopyrrhus_Red-and-white Crake
+Laterallus levraudi_Rusty-flanked Crake
+Laterallus melanophaius_Rufous-sided Crake
+Laterallus ruber_Ruddy Crake
+Laterallus xenopterus_Rufous-faced Crake
+Lathamus discolor_Swift Parrot
+Lathrotriccus euleri_Euler's Flycatcher
+Lathrotriccus griseipectus_Grey-breasted Flycatcher
+Laticilla cinerascens_Swamp Grass Babbler
+Legatus leucophaius_Piratic Flycatcher
+Leiopicus mahrattensis_Yellow-crowned Woodpecker
+Leioptila annectens_Rufous-backed Sibia
+Leiothlypis celata_Orange-crowned Warbler
+Leiothlypis crissalis_Colima Warbler
+Leiothlypis luciae_Lucy's Warbler
+Leiothlypis peregrina_Tennessee Warbler
+Leiothlypis ruficapilla_Nashville Warbler
+Leiothlypis virginiae_Virginia's Warbler
+Leiothrix argentauris_Silver-eared Mesia
+Leiothrix lutea_Red-billed Leiothrix
+Leistes bellicosus_Peruvian Meadowlark
+Leistes loyca_Long-tailed Meadowlark
+Leistes militaris_Red-breasted Meadowlark
+Leistes superciliaris_White-browed Meadowlark
+Lepidocolaptes affinis_Spot-crowned Woodcreeper
+Lepidocolaptes albolineatus_Guianan Woodcreeper
+Lepidocolaptes angustirostris_Narrow-billed Woodcreeper
+Lepidocolaptes duidae_Duida Woodcreeper
+Lepidocolaptes falcinellus_Scalloped Woodcreeper
+Lepidocolaptes fatimalimae_Inambari Woodcreeper
+Lepidocolaptes fuscicapillus_Dusky-capped Woodcreeper
+Lepidocolaptes lacrymiger_Montane Woodcreeper
+Lepidocolaptes leucogaster_White-striped Woodcreeper
+Lepidocolaptes souleyetii_Streak-headed Woodcreeper
+Lepidocolaptes squamatus_Scaled Woodcreeper
+Lepidothrix coronata_Blue-capped Manakin
+Lepidothrix iris_Opal-crowned Manakin
+Lepidothrix isidorei_Blue-rumped Manakin
+Lepidothrix nattereri_Snow-capped Manakin
+Lepidothrix serena_White-fronted Manakin
+Lepidothrix suavissima_Orange-bellied Manakin
+Leptasthenura aegithaloides_Plain-mantled Tit-Spinetail
+Leptasthenura andicola_Andean Tit-Spinetail
+Leptasthenura fuliginiceps_Brown-capped Tit-Spinetail
+Leptasthenura pileata_Rusty-crowned Tit-Spinetail
+Leptasthenura platensis_Tufted Tit-Spinetail
+Leptasthenura setaria_Araucaria Tit-Spinetail
+Leptasthenura striata_Streaked Tit-Spinetail
+Leptasthenura striolata_Striolated Tit-Spinetail
+Leptasthenura xenothorax_White-browed Tit-Spinetail
+Leptocoma aspasia_Black Sunbird
+Leptocoma brasiliana_Van Hasselt's Sunbird
+Leptocoma calcostetha_Copper-throated Sunbird
+Leptocoma minima_Crimson-backed Sunbird
+Leptocoma sperata_Purple-throated Sunbird
+Leptocoma zeylonica_Purple-rumped Sunbird
+Leptodon cayanensis_Grey-headed Kite
+Leptopoecile sophiae_White-browed Tit-Warbler
+Leptopogon amaurocephalus_Sepia-capped Flycatcher
+Leptopogon rufipectus_Rufous-breasted Flycatcher
+Leptopogon superciliaris_Slaty-capped Flycatcher
+Leptopogon taczanowskii_Inca Flycatcher
+Leptoptilos crumenifer_Marabou Stork
+Leptosittaca branickii_Golden-plumed Parakeet
+Leptosomus discolor_Cuckoo-roller
+Leptotila cassinii_Grey-chested Dove
+Leptotila conoveri_Tolima Dove
+Leptotila jamaicensis_Caribbean Dove
+Leptotila megalura_Large-tailed Dove
+Leptotila ochraceiventris_Ochre-bellied Dove
+Leptotila pallida_Pallid Dove
+Leptotila plumbeiceps_Grey-headed Dove
+Leptotila rufaxilla_Grey-fronted Dove
+Leptotila verreauxi_White-tipped Dove
+Lesbia nuna_Green-tailed Trainbearer
+Lesbia victoriae_Black-tailed Trainbearer
+Leucippus fallax_Buffy Hummingbird
+Leucochloris albicollis_White-throated Hummingbird
+Leucogeranus leucogeranus_Siberian Crane
+Leucolia violiceps_Violet-crowned Hummingbird
+Leucophaeus atricilla_Laughing Gull
+Leucophaeus modestus_Grey Gull
+Leucophaeus pipixcan_Franklin's Gull
+Leucophaeus scoresbii_Dolphin Gull
+Leucopternis kuhli_White-browed Hawk
+Leucopternis melanops_Black-faced Hawk
+Leucopternis semiplumbeus_Semiplumbeous Hawk
+Leucosarcia melanoleuca_Wonga Pigeon
+Leucosticte atrata_Black Rosy-Finch
+Leucosticte australis_Brown-capped Rosy-Finch
+Leucosticte tephrocotis_Grey-crowned Rosy-Finch
+Lewinia pectoralis_Lewin's Rail
+Lewinia striata_Slaty-breasted Rail
+Lichenostomus cratitius_Purple-gaped Honeyeater
+Lichenostomus melanops_Yellow-tufted Honeyeater
+Lichmera incana_Dark-brown Honeyeater
+Lichmera indistincta_Brown Honeyeater
+Lichmera limbata_Indonesian Honeyeater
+Lichmera squamata_White-tufted Honeyeater
+Limnoctites rectirostris_Straight-billed Reedhaunter
+Limnoctites sulphuriferus_Sulphur-bearded Reedhaunter
+Limnodromus griseus_Short-billed Dowitcher
+Limnodromus scolopaceus_Long-billed Dowitcher
+Limnodromus semipalmatus_Asian Dowitcher
+Limnornis curvirostris_Curve-billed Reedhaunter
+Limnothlypis swainsonii_Swainson's Warbler
+Limosa fedoa_Marbled Godwit
+Limosa haemastica_Hudsonian Godwit
+Limosa lapponica_Bar-tailed Godwit
+Limosa limosa_Black-tailed Godwit
+Linaria cannabina_Common Linnet
+Linaria flavirostris_Twite
+Linaria yemenensis_Yemen Linnet
+Liocichla phoenicea_Red-faced Liocichla
+Liocichla ripponi_Scarlet-faced Liocichla
+Liocichla steerii_Steere's Liocichla
+Lioparus chrysotis_Golden-breasted Fulvetta
+Liosceles thoracicus_Rusty-belted Tapaculo
+Lipaugus ater_Black-and-gold Cotinga
+Lipaugus fuscocinereus_Dusky Piha
+Lipaugus lanioides_Cinnamon-vented Piha
+Lipaugus unirufus_Rufous Piha
+Lipaugus vociferans_Screaming Piha
+Lipaugus weberi_Chestnut-capped Piha
+Lithobates catesbeianus_American Bullfrog
+Lithobates clamitans_Green Frog
+Lithobates palustris_Pickerel Frog
+Lithobates sylvaticus_Wood Frog
+Lochmias nematura_Sharp-tailed Streamcreeper
+Locustella alishanensis_Taiwan Bush Warbler
+Locustella caudata_Long-tailed Bush Warbler
+Locustella davidi_Baikal Bush Warbler
+Locustella fluviatilis_River Warbler
+Locustella lanceolata_Lanceolated Warbler
+Locustella luscinioides_Savi's Warbler
+Locustella luteoventris_Brown Bush Warbler
+Locustella mandelli_Russet Bush Warbler
+Locustella montis_Javan Bush Warbler
+Locustella naevia_Common Grasshopper Warbler
+Locustella tacsanowskia_Chinese Bush Warbler
+Locustella thoracica_Spotted Bush Warbler
+Lonchura atricapilla_Chestnut Munia
+Lonchura castaneothorax_Chestnut-breasted Munia
+Lonchura kelaarti_Black-throated Munia
+Lonchura leucogastroides_Javan Munia
+Lonchura maja_White-headed Munia
+Lonchura malacca_Tricoloured Munia
+Lonchura punctulata_Scaly-breasted Munia
+Lonchura striata_White-rumped Munia
+Lophaetus occipitalis_Long-crested Eagle
+Lophoceros alboterminatus_Crowned Hornbill
+Lophoceros camurus_Red-billed Dwarf Hornbill
+Lophoceros fasciatus_Congo Pied Hornbill
+Lophoceros hemprichii_Hemprich's Hornbill
+Lophoceros nasutus_African Grey Hornbill
+Lophochroa leadbeateri_Pink Cockatoo
+Lophodytes cucullatus_Hooded Merganser
+Lophonetta specularioides_Crested Duck
+Lophophanes cristatus_Crested Tit
+Lophophanes dichrous_Grey-crested Tit
+Lophophorus impejanus_Himalayan Monal
+Lophorina superba_Greater Lophorina
+Lophostrix cristata_Crested Owl
+Lophotriccus eulophotes_Long-crested Pygmy-Tyrant
+Lophotriccus galeatus_Helmeted Pygmy-Tyrant
+Lophotriccus pileatus_Scale-crested Pygmy-Tyrant
+Lophotriccus vitiosus_Double-banded Pygmy-Tyrant
+Lophotriorchis kienerii_Rufous-bellied Eagle
+Lophura leucomelanos_Kalij Pheasant
+Loriculus beryllinus_Sri Lanka Hanging-Parrot
+Loriculus galgulus_Blue-crowned Hanging-Parrot
+Loriculus philippensis_Philippine Hanging-Parrot
+Loriculus vernalis_Vernal Hanging-Parrot
+Loriotus cristatus_Flame-crested Tanager
+Loriotus luctuosus_White-shouldered Tanager
+Lorius chlorocercus_Yellow-bibbed Lory
+Lorius lory_Black-capped Lory
+Loxia curvirostra_Common Crossbill
+Loxia leucoptera_Two-barred Crossbill
+Loxia pytyopsittacus_Parrot Crossbill
+Loxia scotica_Scottish Crossbill
+Loxia sinesciuris_Cassia Crossbill
+Loxigilla noctis_Lesser Antillean Bullfinch
+Loxioides bailleui_Palila
+Loxops caeruleirostris_Akekee
+Loxops coccineus_Hawaii Akepa
+Loxops mana_Hawaii Creeper
+Lullula arborea_Woodlark
+Lurocalis rufiventris_Rufous-bellied Nighthawk
+Lurocalis semitorquatus_Short-tailed Nighthawk
+Luscinia luscinia_Thrush Nightingale
+Luscinia megarhynchos_Common Nightingale
+Luscinia phaenicuroides_White-bellied Redstart
+Luscinia svecica_Bluethroat
+Lybius bidentatus_Double-toothed Barbet
+Lybius guifsobalito_Black-billed Barbet
+Lybius torquatus_Black-collared Barbet
+Lybius vieilloti_Vieillot's Barbet
+Lycocorax pyrrhopterus_Halmahera Paradise-crow
+Lymnocryptes minimus_Jack Snipe
+Lyncornis macrotis_Great Eared-Nightjar
+Lyncornis temminckii_Malaysian Eared-Nightjar
+Lyrurus tetrix_Black Grouse
+Machaerirhynchus flaviventer_Yellow-breasted Boatbill
+Machaerirhynchus nigripectus_Black-breasted Boatbill
+Machaeropterus deliciosus_Club-winged Manakin
+Machaeropterus pyrocephalus_Fiery-capped Manakin
+Machaeropterus regulus_Kinglet Manakin
+Machaeropterus striolatus_Striolated Manakin
+Macheiramphus alcinus_Bat Hawk
+Machetornis rixosa_Cattle Tyrant
+Machlolophus aplonotus_Indian Yellow Tit
+Machlolophus holsti_Taiwan Yellow Tit
+Machlolophus nuchalis_White-naped Tit
+Machlolophus spilonotus_Yellow-cheeked Tit
+Machlolophus xanthogenys_Himalayan Black-lored Tit
+Mackenziaena leachii_Large-tailed Antshrike
+Mackenziaena severa_Tufted Antshrike
+Macroagelaius imthurni_Golden-tufted Grackle
+Macroagelaius subalaris_Mountain Grackle
+Macronus ptilosus_Fluffy-backed Tit-Babbler
+Macronus striaticeps_Brown Tit-Babbler
+Macronyx capensis_Orange-throated Longclaw
+Macronyx croceus_Yellow-throated Longclaw
+Macronyx fuelleborni_Fülleborn's Longclaw
+Macropygia amboinensis_Amboyna Cuckoo-Dove
+Macropygia doreya_Sultan's Cuckoo-Dove
+Macropygia mackinlayi_Mackinlay's Cuckoo-Dove
+Macropygia phasianella_Brown Cuckoo-Dove
+Macropygia ruficeps_Little Cuckoo-Dove
+Macropygia tenuirostris_Philippine Cuckoo-Dove
+Macropygia unchall_Barred Cuckoo-Dove
+Macrosphenus concolor_Grey Longbill
+Macrosphenus flavicans_Yellow Longbill
+Macrosphenus kempi_Kemp's Longbill
+Magumma parva_Anianiau
+Malacocincla abbotti_Abbott's Babbler
+Malacocincla sepiaria_Horsfield's Babbler
+Malaconotus blanchoti_Grey-headed Bushshrike
+Malacopteron affine_Sooty-capped Babbler
+Malacopteron cinereum_Scaly-crowned Babbler
+Malacopteron magnirostre_Moustached Babbler
+Malacopteron magnum_Rufous-crowned Babbler
+Malacoptila fulvogularis_Black-streaked Puffbird
+Malacoptila fusca_White-chested Puffbird
+Malacoptila mystacalis_Moustached Puffbird
+Malacoptila panamensis_White-whiskered Puffbird
+Malacoptila rufa_Rufous-necked Puffbird
+Malacoptila semicincta_Semicollared Puffbird
+Malacoptila striata_Crescent-chested Puffbird
+Malacorhynchus membranaceus_Pink-eared Duck
+Malcorus pectoralis_Rufous-eared Warbler
+Malia grata_Malia
+Malimbus nitens_Blue-billed Malimbe
+Malindangia mcgregori_McGregor's Cuckooshrike
+Malurus alboscapulatus_White-shouldered Fairywren
+Malurus amabilis_Lovely Fairywren
+Malurus assimilis_Purple-backed Fairywren
+Malurus cyaneus_Superb Fairywren
+Malurus cyanocephalus_Emperor Fairywren
+Malurus elegans_Red-winged Fairywren
+Malurus lamberti_Variegated Fairywren
+Malurus leucopterus_White-winged Fairywren
+Malurus melanocephalus_Red-backed Fairywren
+Malurus splendens_Splendid Fairywren
+Manacus aurantiacus_Orange-collared Manakin
+Manacus candei_White-collared Manakin
+Manacus manacus_White-bearded Manakin
+Manacus vitellinus_Golden-collared Manakin
+Manorina flavigula_Yellow-throated Miner
+Manorina melanocephala_Noisy Miner
+Manorina melanophrys_Bell Miner
+Mareca americana_American Wigeon
+Mareca falcata_Falcated Duck
+Mareca penelope_Eurasian Wigeon
+Mareca sibilatrix_Chiloe Wigeon
+Mareca strepera_Gadwall
+Margarops fuscatus_Pearly-eyed Thrasher
+Margarornis rubiginosus_Ruddy Treerunner
+Margarornis squamiger_Pearled Treerunner
+Masius chrysopterus_Golden-winged Manakin
+Mazaria propinqua_White-bellied Spinetail
+Mecocerculus hellmayri_Buff-banded Tyrannulet
+Mecocerculus leucophrys_White-throated Tyrannulet
+Mecocerculus minor_Sulphur-bellied Tyrannulet
+Mecocerculus poecilocercus_White-tailed Tyrannulet
+Mecocerculus stictopterus_White-banded Tyrannulet
+Megaceryle alcyon_Belted Kingfisher
+Megaceryle lugubris_Crested Kingfisher
+Megaceryle maxima_Giant Kingfisher
+Megaceryle torquata_Ringed Kingfisher
+Megalurus palustris_Striated Grassbird
+Megapodius cumingii_Philippine Megapode
+Megapodius eremita_Melanesian Megapode
+Megapodius freycinet_Dusky Megapode
+Megapodius reinwardt_Orange-footed Megapode
+Megarynchus pitangua_Boat-billed Flycatcher
+Megascops albogularis_White-throated Screech-Owl
+Megascops asio_Eastern Screech-Owl
+Megascops atricapilla_Black-capped Screech-Owl
+Megascops centralis_Choco Screech-Owl
+Megascops choliba_Tropical Screech-Owl
+Megascops clarkii_Bare-shanked Screech-Owl
+Megascops cooperi_Pacific Screech-Owl
+Megascops gilesi_Santa Marta Screech-Owl
+Megascops guatemalae_Middle American Screech-Owl
+Megascops hoyi_Montane Forest Screech-Owl
+Megascops ingens_Rufescent Screech-Owl
+Megascops kennicottii_Western Screech-Owl
+Megascops koepckeae_Koepcke's Screech-Owl
+Megascops petersoni_Cinnamon Screech-Owl
+Megascops roboratus_Peruvian Screech-Owl
+Megascops roraimae_Foothill Screech-Owl
+Megascops sanctaecatarinae_Long-tufted Screech-Owl
+Megascops seductus_Balsas Screech-Owl
+Megascops trichopsis_Whiskered Screech-Owl
+Megascops watsonii_Tawny-bellied Screech-Owl
+Megastictus margaritatus_Pearly Antshrike
+Megaxenops parnaguae_Great Xenops
+Meiglyptes tristis_Zebra Woodpecker
+Meiglyptes tukki_Buff-necked Woodpecker
+Melaenornis edolioides_Northern Black-Flycatcher
+Melaenornis fischeri_White-eyed Slaty-Flycatcher
+Melaenornis pammelaina_Southern Black-Flycatcher
+Melaenornis silens_Fiscal Flycatcher
+Melampitta lugubris_Lesser Melampitta
+Melanerpes aurifrons_Golden-fronted Woodpecker
+Melanerpes cactorum_White-fronted Woodpecker
+Melanerpes candidus_White Woodpecker
+Melanerpes carolinus_Red-bellied Woodpecker
+Melanerpes chrysauchen_Golden-naped Woodpecker
+Melanerpes chrysogenys_Golden-cheeked Woodpecker
+Melanerpes cruentatus_Yellow-tufted Woodpecker
+Melanerpes erythrocephalus_Red-headed Woodpecker
+Melanerpes flavifrons_Yellow-fronted Woodpecker
+Melanerpes formicivorus_Acorn Woodpecker
+Melanerpes hoffmannii_Hoffmann's Woodpecker
+Melanerpes hypopolius_Grey-breasted Woodpecker
+Melanerpes lewis_Lewis's Woodpecker
+Melanerpes portoricensis_Puerto Rican Woodpecker
+Melanerpes pucherani_Black-cheeked Woodpecker
+Melanerpes pygmaeus_Yucatan Woodpecker
+Melanerpes radiolatus_Jamaican Woodpecker
+Melanerpes rubricapillus_Red-crowned Woodpecker
+Melanerpes striatus_Hispaniolan Woodpecker
+Melanerpes superciliaris_West Indian Woodpecker
+Melanerpes uropygialis_Gila Woodpecker
+Melaniparus afer_Grey Tit
+Melaniparus albiventris_White-bellied Tit
+Melaniparus cinerascens_Ashy Tit
+Melaniparus funereus_Dusky Tit
+Melaniparus leucomelas_White-winged Black-Tit
+Melaniparus niger_Southern Black-Tit
+Melaniparus rufiventris_Rufous-bellied Tit
+Melaniparus thruppi_Somali Tit
+Melanitta americana_Black Scoter
+Melanitta fusca_Velvet Scoter
+Melanitta nigra_Common Scoter
+Melanitta perspicillata_Surf Scoter
+Melanochlora sultanea_Sultan Tit
+Melanocorypha calandra_Calandra Lark
+Melanocorypha maxima_Tibetan Lark
+Melanodera melanodera_White-bridled Finch
+Melanodera xanthogramma_Yellow-bridled Finch
+Melanodryas cucullata_Hooded Robin
+Melanodryas vittata_Dusky Robin
+Melanopareia elegans_Elegant Crescentchest
+Melanopareia maranonica_Marañon Crescentchest
+Melanopareia maximiliani_Olive-crowned Crescentchest
+Melanopareia torquata_Collared Crescentchest
+Melanoptila glabrirostris_Black Catbird
+Melanorectes nigrescens_Black Pitohui
+Melanospiza bicolor_Black-faced Grassquit
+Melanotis caerulescens_Blue Mockingbird
+Melanotis hypoleucus_Blue-and-white Mockingbird
+Meleagris gallopavo_Wild Turkey
+Meleagris ocellata_Ocellated Turkey
+Meliarchus sclateri_Makira Honeyeater
+Melidectes belfordi_Belford's Melidectes
+Melidectes rufocrissalis_Yellow-browed Melidectes
+Melidora macrorrhina_Hook-billed Kingfisher
+Meliphaga lewinii_Lewin's Honeyeater
+Meliphaga notata_Yellow-spotted Honeyeater
+Melithreptus affinis_Black-headed Honeyeater
+Melithreptus albogularis_White-throated Honeyeater
+Melithreptus brevirostris_Brown-headed Honeyeater
+Melithreptus chloropsis_Gilbert's Honeyeater
+Melithreptus gularis_Black-chinned Honeyeater
+Melithreptus lunatus_White-naped Honeyeater
+Melithreptus validirostris_Strong-billed Honeyeater
+Mellisuga helenae_Bee Hummingbird
+Mellisuga minima_Vervain Hummingbird
+Melocichla mentalis_Moustached Grass-Warbler
+Melopsittacus undulatus_Budgerigar
+Melopyrrha portoricensis_Puerto Rican Bullfinch
+Melopyrrha violacea_Greater Antillean Bullfinch
+Melospiza georgiana_Swamp Sparrow
+Melospiza lincolnii_Lincoln's Sparrow
+Melospiza melodia_Song Sparrow
+Melozone aberti_Abert's Towhee
+Melozone albicollis_White-throated Towhee
+Melozone biarcuata_White-faced Ground-Sparrow
+Melozone cabanisi_Cabanis's Ground-Sparrow
+Melozone crissalis_California Towhee
+Melozone fusca_Canyon Towhee
+Melozone kieneri_Rusty-crowned Ground-Sparrow
+Melozone leucotis_White-eared Ground-Sparrow
+Menura alberti_Albert's Lyrebird
+Menura novaehollandiae_Superb Lyrebird
+Mergellus albellus_Smew
+Mergus merganser_Goosander
+Mergus serrator_Red-breasted Merganser
+Merops albicollis_White-throated Bee-eater
+Merops apiaster_European Bee-eater
+Merops bullockoides_White-fronted Bee-eater
+Merops bulocki_Red-throated Bee-eater
+Merops hirundineus_Swallow-tailed Bee-eater
+Merops leschenaulti_Chestnut-headed Bee-eater
+Merops oreobates_Cinnamon-chested Bee-eater
+Merops orientalis_Asian Green Bee-eater
+Merops ornatus_Rainbow Bee-eater
+Merops persicus_Blue-cheeked Bee-eater
+Merops philippinus_Blue-tailed Bee-eater
+Merops pusillus_Little Bee-eater
+Merops superciliosus_Madagascar Bee-eater
+Merops variegatus_Blue-breasted Bee-eater
+Merops viridis_Blue-throated Bee-eater
+Merulaxis ater_Slaty Bristlefront
+Mesembrinibis cayennensis_Green Ibis
+Mesitornis unicolor_Brown Mesite
+Mesitornis variegatus_White-breasted Mesite
+Metallura tyrianthina_Tyrian Metaltail
+Metallura williami_Viridian Metaltail
+Metopidius indicus_Bronze-winged Jacana
+Metopothrix aurantiaca_Orange-fronted Plushcrown
+Metriopelia melanoptera_Black-winged Ground Dove
+Micrastur buckleyi_Buckley's Forest-Falcon
+Micrastur gilvicollis_Lined Forest-Falcon
+Micrastur mintoni_Cryptic Forest-Falcon
+Micrastur mirandollei_Slaty-backed Forest-Falcon
+Micrastur ruficollis_Barred Forest-Falcon
+Micrastur semitorquatus_Collared Forest-Falcon
+Micrathene whitneyi_Elf Owl
+Microbates cinereiventris_Tawny-faced Gnatwren
+Microbates collaris_Collared Gnatwren
+Microcarbo niger_Little Cormorant
+Microcentrum rhombifolium_Greater Angle-wing
+Microcerculus bambla_Wing-banded Wren
+Microcerculus marginatus_Scaly-breasted Wren
+Microcerculus philomela_Nightingale Wren
+Microcerculus ustulatus_Flutist Wren
+Microeca fascinans_Jacky-winter
+Microeca flavigaster_Lemon-bellied Flyrobin
+Microhierax fringillarius_Black-thighed Falconet
+Micromonacha lanceolata_Lanceolated Monklet
+Micronisus gabar_Gabar Goshawk
+Micropsitta finschii_Finsch's Pygmy-Parrot
+Micropternus brachyurus_Rufous Woodpecker
+Micropygia schomburgkii_Ocellated Crake
+Microrhopias quixensis_Dot-winged Antwren
+Microspingus cabanisi_Grey-throated Warbling Finch
+Microspingus erythrophrys_Rusty-browed Warbling Finch
+Microspingus lateralis_Buff-throated Warbling Finch
+Microspingus melanoleucus_Black-capped Warbling Finch
+Microspingus torquatus_Ringed Warbling Finch
+Microxenops milleri_Rufous-tailed Xenops
+Milvago chimachima_Yellow-headed Caracara
+Milvago chimango_Chimango Caracara
+Milvus migrans_Black Kite
+Milvus milvus_Red Kite
+Mimus dorsalis_Brown-backed Mockingbird
+Mimus gilvus_Tropical Mockingbird
+Mimus gundlachii_Bahama Mockingbird
+Mimus longicaudatus_Long-tailed Mockingbird
+Mimus patagonicus_Patagonian Mockingbird
+Mimus polyglottos_Northern Mockingbird
+Mimus saturninus_Chalk-browed Mockingbird
+Mimus thenca_Chilean Mockingbird
+Mimus triurus_White-banded Mockingbird
+Minla ignotincta_Red-tailed Minla
+Mino dumontii_Yellow-faced Myna
+Mino kreffti_Long-tailed Myna
+Miogryllus saussurei_Miogryllus saussurei
+Mionectes macconnelli_McConnell's Flycatcher
+Mionectes oleagineus_Ochre-bellied Flycatcher
+Mionectes olivaceus_Olive-streaked Flycatcher
+Mionectes rufiventris_Grey-hooded Flycatcher
+Mionectes striaticollis_Streak-necked Flycatcher
+Mirafra affinis_Jerdon's Bushlark
+Mirafra africana_Rufous-naped Lark
+Mirafra apiata_Cape Clapper Lark
+Mirafra assamica_Bengal Bushlark
+Mirafra cantillans_Singing Bushlark
+Mirafra cheniana_Melodious Lark
+Mirafra erythrocephala_Indochinese Bushlark
+Mirafra erythroptera_Indian Bushlark
+Mirafra fasciolata_Eastern Clapper Lark
+Mirafra javanica_Singing Bushlark
+Mirafra passerina_Monotonous Lark
+Mirafra rufocinnamomea_Flappet Lark
+Mitrephanes phaeocercus_Tufted Flycatcher
+Mitrospingus cassinii_Dusky-faced Tanager
+Mitrospingus oleagineus_Olive-backed Tanager
+Mitu salvini_Salvin's Curassow
+Mitu tomentosum_Crestless Curassow
+Mitu tuberosum_Razor-billed Curassow
+Mixornis bornensis_Bold-striped Tit-Babbler
+Mixornis flavicollis_Grey-cheeked Tit-Babbler
+Mixornis gularis_Pin-striped Tit-Babbler
+Mixornis kelleyi_Grey-faced Tit-Babbler
+Mniotilta varia_Black-and-white Warbler
+Modulatrix stictigula_Spot-throat
+Mohoua albicilla_Whitehead
+Mohoua novaeseelandiae_Pipipi
+Mohoua ochrocephala_Yellowhead
+Molothrus aeneus_Bronzed Cowbird
+Molothrus ater_Brown-headed Cowbird
+Molothrus bonariensis_Shiny Cowbird
+Molothrus oryzivorus_Giant Cowbird
+Molothrus rufoaxillaris_Screaming Cowbird
+Momotus aequatorialis_Andean Motmot
+Momotus coeruliceps_Blue-capped Motmot
+Momotus lessonii_Lesson's Motmot
+Momotus mexicanus_Russet-crowned Motmot
+Momotus momota_Amazonian Motmot
+Momotus subrufescens_Whooping Motmot
+Monarcha castaneiventris_Chestnut-bellied Monarch
+Monarcha frater_Black-winged Monarch
+Monarcha melanopsis_Black-faced Monarch
+Monarcha richardsii_White-capped Monarch
+Monasa atra_Black Nunbird
+Monasa flavirostris_Yellow-billed Nunbird
+Monasa morphoeus_White-fronted Nunbird
+Monasa nigrifrons_Black-fronted Nunbird
+Montecincla fairbanki_Palani Laughingthrush
+Monticola cinclorhyncha_Blue-capped Rock Thrush
+Monticola gularis_White-throated Rock Thrush
+Monticola rufiventris_Chestnut-bellied Rock Thrush
+Monticola rupestris_Cape Rock Thrush
+Monticola saxatilis_Common Rock Thrush
+Monticola sharpei_Forest Rock Thrush
+Monticola solitarius_Blue Rock Thrush
+Montifringilla blanfordi_Blanford's Snowfinch
+Montifringilla nivalis_White-winged Snowfinch
+Montifringilla taczanowskii_White-rumped Snowfinch
+Morococcyx erythropygus_Lesser Ground-Cuckoo
+Morphnarchus princeps_Barred Hawk
+Morphnus guianensis_Crested Eagle
+Morus bassanus_Northern Gannet
+Motacilla aguimp_African Pied Wagtail
+Motacilla alba_Pied Wagtail/White Wagtail
+Motacilla capensis_Cape Wagtail
+Motacilla cinerea_Grey Wagtail
+Motacilla citreola_Citrine Wagtail
+Motacilla clara_Mountain Wagtail
+Motacilla flava_Western Yellow Wagtail
+Motacilla flaviventris_Madagascar Wagtail
+Motacilla grandis_Japanese Wagtail
+Motacilla maderaspatensis_White-browed Wagtail
+Motacilla tschutschensis_Eastern Yellow Wagtail
+Mulleripicus fulvus_Ashy Woodpecker
+Mulleripicus pulverulentus_Great Slaty Woodpecker
+Muscicapa adusta_African Dusky Flycatcher
+Muscicapa aquatica_Swamp Flycatcher
+Muscicapa dauurica_Asian Brown Flycatcher
+Muscicapa ferruginea_Ferruginous Flycatcher
+Muscicapa griseisticta_Grey-streaked Flycatcher
+Muscicapa muttui_Brown-breasted Flycatcher
+Muscicapa sibirica_Dark-sided Flycatcher
+Muscicapa striata_Spotted Flycatcher
+Muscicapa williamsoni_Brown-streaked Flycatcher
+Muscigralla brevicauda_Short-tailed Field Tyrant
+Muscipipra vetula_Shear-tailed Grey Tyrant
+Muscisaxicola albilora_White-browed Ground-Tyrant
+Muscisaxicola maculirostris_Spot-billed Ground-Tyrant
+Musophaga rossae_Ross's Turaco
+Mustelirallus albicollis_Ash-throated Crake
+Mustelirallus erythrops_Paint-billed Crake
+Myadestes coloratus_Varied Solitaire
+Myadestes elisabeth_Cuban Solitaire
+Myadestes genibarbis_Rufous-throated Solitaire
+Myadestes melanops_Black-faced Solitaire
+Myadestes obscurus_Omao
+Myadestes occidentalis_Brown-backed Solitaire
+Myadestes palmeri_Puaiohi
+Myadestes ralloides_Andean Solitaire
+Myadestes townsendi_Townsend's Solitaire
+Myadestes unicolor_Slate-coloured Solitaire
+Mycerobas affinis_Collared Grosbeak
+Mycerobas carnipes_White-winged Grosbeak
+Mycerobas icterioides_Black-and-yellow Grosbeak
+Mycteria americana_Wood Stork
+Mycteria leucocephala_Painted Stork
+Myiagra alecto_Shining Flycatcher
+Myiagra caledonica_Melanesian Flycatcher
+Myiagra cyanoleuca_Satin Flycatcher
+Myiagra ferrocyanea_Steel-blue Flycatcher
+Myiagra galeata_Moluccan Flycatcher
+Myiagra inquieta_Restless Flycatcher
+Myiagra nana_Paperbark Flycatcher
+Myiagra rubecula_Leaden Flycatcher
+Myiagra ruficollis_Broad-billed Flycatcher
+Myiagra vanikorensis_Vanikoro Flycatcher
+Myiarchus antillarum_Puerto Rican Flycatcher
+Myiarchus apicalis_Apical Flycatcher
+Myiarchus barbirostris_Sad Flycatcher
+Myiarchus cephalotes_Pale-edged Flycatcher
+Myiarchus cinerascens_Ash-throated Flycatcher
+Myiarchus crinitus_Great Crested Flycatcher
+Myiarchus ferox_Short-crested Flycatcher
+Myiarchus nuttingi_Nutting's Flycatcher
+Myiarchus panamensis_Panama Flycatcher
+Myiarchus phaeocephalus_Sooty-crowned Flycatcher
+Myiarchus sagrae_La Sagra's Flycatcher
+Myiarchus stolidus_Stolid Flycatcher
+Myiarchus swainsoni_Swainson's Flycatcher
+Myiarchus tuberculifer_Dusky-capped Flycatcher
+Myiarchus tyrannulus_Brown-crested Flycatcher
+Myiarchus venezuelensis_Venezuelan Flycatcher
+Myiarchus yucatanensis_Yucatan Flycatcher
+Myiobius atricaudus_Black-tailed Flycatcher
+Myiobius barbatus_Whiskered Flycatcher
+Myiobius sulphureipygius_Sulphur-rumped Flycatcher
+Myioborus albifrons_White-fronted Redstart
+Myioborus brunniceps_Brown-capped Redstart
+Myioborus castaneocapilla_Tepui Redstart
+Myioborus flavivertex_Yellow-crowned Redstart
+Myioborus melanocephalus_Spectacled Redstart
+Myioborus miniatus_Slate-throated Redstart
+Myioborus ornatus_Golden-fronted Redstart
+Myioborus pictus_Painted Redstart
+Myioborus torquatus_Collared Redstart
+Myiodynastes bairdii_Baird's Flycatcher
+Myiodynastes chrysocephalus_Golden-crowned Flycatcher
+Myiodynastes hemichrysus_Golden-bellied Flycatcher
+Myiodynastes luteiventris_Sulphur-bellied Flycatcher
+Myiodynastes maculatus_Streaked Flycatcher
+Myiomela leucura_White-tailed Robin
+Myiopagis caniceps_Grey-headed Elaenia
+Myiopagis flavivertex_Yellow-crowned Elaenia
+Myiopagis gaimardii_Forest Elaenia
+Myiopagis olallai_Foothill Elaenia
+Myiopagis subplacens_Pacific Elaenia
+Myiopagis viridicata_Greenish Elaenia
+Myiophobus cryptoxanthus_Olive-chested Flycatcher
+Myiophobus fasciatus_Bran-coloured Flycatcher
+Myiophobus flavicans_Flavescent Flycatcher
+Myiophobus phoenicomitra_Orange-crested Flycatcher
+Myiopsitta monachus_Monk Parakeet
+Myiornis albiventris_White-bellied Pygmy-Tyrant
+Myiornis atricapillus_Black-capped Pygmy-Tyrant
+Myiornis auricularis_Eared Pygmy-Tyrant
+Myiornis ecaudatus_Short-tailed Pygmy-Tyrant
+Myiotheretes fumigatus_Smoky Bush-Tyrant
+Myiotheretes fuscorufus_Rufous-bellied Bush-Tyrant
+Myiotheretes pernix_Santa Marta Bush-Tyrant
+Myiotheretes striaticollis_Streak-throated Bush-Tyrant
+Myiothlypis basilica_Santa Marta Warbler
+Myiothlypis bivittata_Two-banded Warbler
+Myiothlypis chrysogaster_Cuzco Warbler
+Myiothlypis cinereicollis_Grey-throated Warbler
+Myiothlypis conspicillata_White-lored Warbler
+Myiothlypis coronata_Russet-crowned Warbler
+Myiothlypis flaveola_Flavescent Warbler
+Myiothlypis fraseri_Grey-and-gold Warbler
+Myiothlypis fulvicauda_Buff-rumped Warbler
+Myiothlypis leucoblephara_White-browed Warbler
+Myiothlypis leucophrys_White-striped Warbler
+Myiothlypis luteoviridis_Citrine Warbler
+Myiothlypis nigrocristata_Black-crested Warbler
+Myiothlypis rivularis_Riverbank Warbler
+Myiothlypis signata_Pale-legged Warbler
+Myiotriccus ornatus_Ornate Flycatcher
+Myiozetetes cayanensis_Rusty-margined Flycatcher
+Myiozetetes granadensis_Grey-capped Flycatcher
+Myiozetetes luteiventris_Dusky-chested Flycatcher
+Myiozetetes similis_Social Flycatcher
+Myophonus caeruleus_Blue Whistling-Thrush
+Myophonus horsfieldii_Malabar Whistling-Thrush
+Myophonus insularis_Taiwan Whistling-Thrush
+Myophonus melanurus_Shiny Whistling-Thrush
+Myornis senilis_Ash-coloured Tapaculo
+Myrmeciza longipes_White-bellied Antbird
+Myrmecocichla aethiops_Northern Anteater-Chat
+Myrmecocichla arnotti_Arnot's Chat
+Myrmecocichla formicivora_Southern Anteater-Chat
+Myrmecocichla monticola_Mountain Wheatear
+Myrmecocichla nigra_Sooty Chat
+Myrmelastes humaythae_Humaita Antbird
+Myrmelastes hyperythrus_Plumbeous Antbird
+Myrmelastes leucostigma_Spot-winged Antbird
+Myrmelastes rufifacies_Rufous-faced Antbird
+Myrmelastes schistaceus_Slate-coloured Antbird
+Myrmoborus leucophrys_White-browed Antbird
+Myrmoborus lophotes_White-lined Antbird
+Myrmoborus lugubris_Ash-breasted Antbird
+Myrmoborus melanurus_Black-tailed Antbird
+Myrmoborus myotherinus_Black-faced Antbird
+Myrmochanes hemileucus_Black-and-white Antbird
+Myrmoderus ferrugineus_Ferruginous-backed Antbird
+Myrmoderus loricatus_White-bibbed Antbird
+Myrmoderus ruficauda_Scalloped Antbird
+Myrmoderus squamosus_Squamate Antbird
+Myrmophylax atrothorax_Black-throated Antbird
+Myrmorchilus strigilatus_Stripe-backed Antbird
+Myrmornis torquata_Wing-banded Antbird
+Myrmothera berlepschi_Amazonian Antpitta
+Myrmothera campanisona_Thrush-like Antpitta
+Myrmothera dives_Thicket Antpitta
+Myrmothera fulviventris_White-lored Antpitta
+Myrmothera simplex_Tepui Antpitta
+Myrmothera subcanescens_Tapajos Antpitta
+Myrmotherula ambigua_Yellow-throated Antwren
+Myrmotherula assimilis_Leaden Antwren
+Myrmotherula axillaris_White-flanked Antwren
+Myrmotherula brachyura_Pygmy Antwren
+Myrmotherula cherriei_Cherrie's Antwren
+Myrmotherula ignota_Moustached Antwren
+Myrmotherula iheringi_Ihering's Antwren
+Myrmotherula klagesi_Klages's Antwren
+Myrmotherula longicauda_Stripe-chested Antwren
+Myrmotherula longipennis_Long-winged Antwren
+Myrmotherula menetriesii_Grey Antwren
+Myrmotherula minor_Salvadori's Antwren
+Myrmotherula multostriata_Amazonian Streaked-Antwren
+Myrmotherula pacifica_Pacific Antwren
+Myrmotherula schisticolor_Slaty Antwren
+Myrmotherula sclateri_Sclater's Antwren
+Myrmotherula surinamensis_Guianan Streaked-Antwren
+Myrmotherula unicolor_Unicoloured Antwren
+Myrmotherula urosticta_Band-tailed Antwren
+Myrtis fanny_Purple-collared Woodstar
+Mystacornis crossleyi_Crossley's Vanga
+Myza sarasinorum_White-eared Myza
+Myzomela cardinalis_Cardinal Myzomela
+Myzomela erythrocephala_Red-headed Myzomela
+Myzomela obscura_Dusky Myzomela
+Myzomela rosenbergii_Red-collared Myzomela
+Myzomela rubratra_Micronesian Myzomela
+Myzomela sanguinolenta_Scarlet Myzomela
+Nannopsittaca panychlora_Tepui Parrotlet
+Nannopterum auritum_Double-crested Cormorant
+Nannopterum brasilianum_Neotropic Cormorant
+Napothera danjoui_Short-tailed Scimitar-Babbler
+Napothera epilepidota_Eyebrowed Wren-Babbler
+Napothera malacoptila_Long-billed Wren-Babbler
+Nasica longirostris_Long-billed Woodcreeper
+Nectarinia famosa_Malachite Sunbird
+Nectarinia kilimensis_Bronze Sunbird
+Nemosia pileata_Hooded Tanager
+Nengetus cinereus_Grey Monjita
+Neochmia phaeton_Crimson Finch
+Neochmia temporalis_Red-browed Firetail
+Neoconocephalus bivocatus_False Robust Conehead
+Neoconocephalus ensiger_Sword-bearing Conehead
+Neoconocephalus retusus_Round-tipped Conehead
+Neoconocephalus robustus_Robust Conehead
+Neocossyphus finschi_Finsch's Flycatcher-Thrush
+Neocossyphus fraseri_Rufous Flycatcher-Thrush
+Neocossyphus poensis_White-tailed Ant-Thrush
+Neocossyphus rufus_Red-tailed Ant-Thrush
+Neoctantes niger_Black Bushbird
+Neomixis striatigula_Stripe-throated Jery
+Neomixis tenella_Common Jery
+Neomorphus geoffroyi_Rufous-vented Ground-Cuckoo
+Neomorphus rufipennis_Rufous-winged Ground-Cuckoo
+Neonemobius cubensis_Cuban Ground Cricket
+Neopelma aurifrons_Wied's Tyrant-Manakin
+Neopelma chrysocephalum_Saffron-crested Tyrant-Manakin
+Neopelma chrysolophum_Serra do Mar Tyrant-Manakin
+Neopelma pallescens_Pale-bellied Tyrant-Manakin
+Neopelma sulphureiventer_Sulphur-bellied Tyrant-Manakin
+Neophema pulchella_Turquoise Parrot
+Neopipo cinnamomea_Cinnamon Manakin-Tyrant
+Neothraupis fasciata_White-banded Tanager
+Nephelomyias lintoni_Orange-banded Flycatcher
+Nephelomyias pulcher_Handsome Flycatcher
+Nesillas lantzii_Subdesert Brush-Warbler
+Nesillas typica_Malagasy Brush-Warbler
+Nesoenas mayeri_Pink Pigeon
+Nesoptilotis flavicollis_Yellow-throated Honeyeater
+Nesoptilotis leucotis_White-eared Honeyeater
+Nesospingus speculiferus_Puerto Rican Tanager
+Nestor meridionalis_New Zealand Kaka
+Netta rufina_Red-crested Pochard
+Nettapus coromandelianus_Cotton Pygmy-Goose
+Newtonia amphichroa_Dark Newtonia
+Newtonia archboldi_Archbold's Newtonia
+Newtonia brunneicauda_Common Newtonia
+Nicator chloris_Western Nicator
+Nicator gularis_Eastern Nicator
+Nicator vireo_Yellow-throated Nicator
+Nigrita canicapillus_Grey-headed Nigrita
+Nilaus afer_Brubru
+Niltava grandis_Large Niltava
+Niltava macgrigoriae_Small Niltava
+Niltava sundara_Rufous-bellied Niltava
+Niltava vivida_Taiwan Vivid Niltava
+Ninox boobook_Southern Boobook
+Ninox connivens_Barking Owl
+Ninox ios_Cinnabar Boobook
+Ninox japonica_Northern Boobook
+Ninox novaeseelandiae_Morepork
+Ninox obscura_Hume's Boobook
+Ninox philippensis_Luzon Boobook
+Ninox scutulata_Brown Boobook
+Ninox strenua_Powerful Owl
+Ninox theomacha_Papuan Boobook
+Nisaetus cirrhatus_Changeable Hawk-Eagle
+Nisaetus nanus_Wallace's Hawk-Eagle
+Nisaetus nipalensis_Mountain Hawk-Eagle
+Noise_Noise
+Nonnula brunnea_Brown Nunlet
+Nonnula frontalis_Grey-cheeked Nunlet
+Nonnula rubecula_Rusty-breasted Nunlet
+Nonnula ruficapilla_Rufous-capped Nunlet
+Northiella haematogaster_Greater Bluebonnet
+Notharchus hyperrhynchus_White-necked Puffbird
+Notharchus macrorhynchos_Guianan Puffbird
+Notharchus ordii_Brown-banded Puffbird
+Notharchus pectoralis_Black-breasted Puffbird
+Notharchus swainsoni_Buff-bellied Puffbird
+Notharchus tectus_Pied Puffbird
+Nothocercus bonapartei_Highland Tinamou
+Nothocercus julius_Tawny-breasted Tinamou
+Nothocercus nigrocapillus_Hooded Tinamou
+Nothocrax urumutum_Nocturnal Curassow
+Nothoprocta cinerascens_Brushland Tinamou
+Nothoprocta ornata_Ornate Tinamou
+Nothoprocta pentlandii_Andean Tinamou
+Nothoprocta perdicaria_Chilean Tinamou
+Nothura boraquira_White-bellied Nothura
+Nothura darwinii_Darwin's Nothura
+Nothura maculosa_Spotted Nothura
+Notiomystis cincta_Stitchbird
+Notopholia corusca_Black-bellied Starling
+Nucifraga caryocatactes_Spotted Nutcracker
+Nucifraga columbiana_Clark's Nutcracker
+Numenius americanus_Long-billed Curlew
+Numenius arquata_Eurasian Curlew
+Numenius madagascariensis_Far Eastern Curlew
+Numenius minutus_Little Whimbrel
+Numenius phaeopus_Whimbrel
+Numenius tahitiensis_Bristle-thighed Curlew
+Numida meleagris_Helmeted Guineafowl
+Nyctanassa violacea_Yellow-crowned Night Heron
+Nyctibius aethereus_Long-tailed Potoo
+Nyctibius bracteatus_Rufous Potoo
+Nyctibius grandis_Great Potoo
+Nyctibius griseus_Common Potoo
+Nyctibius jamaicensis_Northern Potoo
+Nyctibius leucopterus_White-winged Potoo
+Nycticorax nycticorax_Black-crowned Night Heron
+Nyctidromus albicollis_Common Pauraque
+Nyctidromus anthonyi_Scrub Nightjar
+Nyctiphrynus mcleodii_Eared Poorwill
+Nyctiphrynus ocellatus_Ocellated Poorwill
+Nyctiphrynus rosenbergi_Choco Poorwill
+Nyctiphrynus yucatanicus_Yucatan Poorwill
+Nyctipolus nigrescens_Blackish Nightjar
+Nyctiprogne leucopyga_Band-tailed Nighthawk
+Nyctyornis amictus_Red-bearded Bee-eater
+Nyctyornis athertoni_Blue-bearded Bee-eater
+Nymphicus hollandicus_Cockatiel
+Nystalus chacuru_White-eared Puffbird
+Nystalus maculatus_Spot-backed Puffbird
+Nystalus obamai_Western Striolated-Puffbird
+Nystalus radiatus_Barred Puffbird
+Nystalus striolatus_Eastern Striolated-Puffbird
+Ochetorhynchus andaecola_Rock Earthcreeper
+Ochetorhynchus melanurus_Crag Chilia
+Ochetorhynchus phoenicurus_Band-tailed Earthcreeper
+Ochetorhynchus ruficaudus_Straight-billed Earthcreeper
+Ochthoeca cinnamomeiventris_Chestnut-bellied Chat-Tyrant
+Ochthoeca diadema_Yellow-bellied Chat-Tyrant
+Ochthoeca frontalis_Crowned Chat-Tyrant
+Ochthoeca fumicolor_Brown-backed Chat-Tyrant
+Ochthoeca jelskii_Jelski's Chat-Tyrant
+Ochthoeca leucophrys_White-browed Chat-Tyrant
+Ochthoeca oenanthoides_d'Orbigny's Chat-Tyrant
+Ochthoeca pulchella_Golden-browed Chat-Tyrant
+Ochthoeca rufipectoralis_Rufous-breasted Chat-Tyrant
+Ochthornis littoralis_Drab Water Tyrant
+Ocreatus underwoodii_White-booted Racket-tail
+Ocyceros birostris_Indian Grey Hornbill
+Ocyceros gingalensis_Sri Lanka Grey Hornbill
+Ocyceros griseus_Malabar Grey Hornbill
+Ocyphaps lophotes_Crested Pigeon
+Odocoileus virginianus_White-tailed Deer
+Odontophorus atrifrons_Black-fronted Wood-Quail
+Odontophorus balliviani_Stripe-faced Wood-Quail
+Odontophorus capueira_Spot-winged Wood-Quail
+Odontophorus columbianus_Venezuelan Wood-Quail
+Odontophorus erythrops_Rufous-fronted Wood-Quail
+Odontophorus gujanensis_Marbled Wood-Quail
+Odontophorus guttatus_Spotted Wood-Quail
+Odontophorus hyperythrus_Chestnut Wood-Quail
+Odontophorus leucolaemus_Black-breasted Wood-Quail
+Odontophorus melanonotus_Dark-backed Wood-Quail
+Odontophorus melanotis_Black-eared Wood-Quail
+Odontophorus speciosus_Rufous-breasted Wood-Quail
+Odontophorus stellatus_Starred Wood-Quail
+Odontophorus strophium_Gorgeted Wood-Quail
+Odontorchilus branickii_Grey-mantled Wren
+Odontorchilus cinereus_Tooth-billed Wren
+Oecanthus celerinictus_Fast-calling Tree Cricket
+Oecanthus exclamationis_Davis's Tree Cricket
+Oecanthus fultoni_Snowy Tree Cricket
+Oecanthus nigricornis_Blackhorned Tree Cricket
+Oecanthus niveus_Narrow-winged Tree Cricket
+Oecanthus pini_Pine Tree Cricket
+Oecanthus quadripunctatus_Four-spotted Tree Cricket
+Oena capensis_Namaqua Dove
+Oenanthe deserti_Desert Wheatear
+Oenanthe familiaris_Familiar Chat
+Oenanthe fusca_Brown Rock Chat
+Oenanthe hispanica_Western Black-eared Wheatear
+Oenanthe isabellina_Isabelline Wheatear
+Oenanthe leucopyga_White-crowned Wheatear
+Oenanthe leucura_Black Wheatear
+Oenanthe melanoleuca_Eastern Black-eared Wheatear
+Oenanthe melanura_Blackstart
+Oenanthe oenanthe_Northern Wheatear
+Oenanthe pileata_Capped Wheatear
+Oenanthe pleschanka_Pied Wheatear
+Oenanthe scotocerca_Brown-tailed Chat
+Ognorhynchus icterotis_Yellow-eared Parrot
+Oncostoma cinereigulare_Northern Bentbill
+Oncostoma olivaceum_Southern Bentbill
+Oneillornis lunulatus_Lunulated Antbird
+Oneillornis salvini_White-throated Antbird
+Onychognathus morio_Red-winged Starling
+Onychognathus nabouroup_Pale-winged Starling
+Onychognathus tenuirostris_Slender-billed Starling
+Onychognathus tristramii_Tristram's Starling
+Onychognathus walleri_Waller's Starling
+Onychoprion aleuticus_Aleutian Tern
+Onychoprion anaethetus_Bridled Tern
+Onychoprion fuscatus_Sooty Tern
+Onychoprion lunatus_Grey-backed Tern
+Onychorhynchus coronatus_Tropical Royal Flycatcher
+Opisthocomus hoazin_Hoatzin
+Oporornis agilis_Connecticut Warbler
+Orchelimum agile_Agile Meadow Katydid
+Orchelimum concinnum_Stripe-faced Meadow Katydid
+Orchelimum pulchellum_Handsome Meadow Katydid
+Orchesticus abeillei_Brown Tanager
+Oreocharis arfaki_Tit Berrypecker
+Oreoica gutturalis_Crested Bellbird
+Oreolais pulcher_Black-collared Apalis
+Oreolais ruwenzorii_Rwenzori Apalis
+Oreomystis bairdi_Akikiki
+Oreophasis derbianus_Horned Guan
+Oreopholus ruficollis_Tawny-throated Dotterel
+Oreopsar bolivianus_Bolivian Blackbird
+Oreortyx pictus_Mountain Quail
+Oreoscoptes montanus_Sage Thrasher
+Oreoscopus gutturalis_Fernwren
+Oreothlypis gutturalis_Flame-throated Warbler
+Oreothlypis superciliosa_Crescent-chested Warbler
+Oreothraupis arremonops_Tanager Finch
+Oreotrochilus estella_Andean Hillstar
+Oressochen jubatus_Orinoco Goose
+Oressochen melanopterus_Andean Goose
+Oriolus auratus_African Golden Oriole
+Oriolus brachyrynchus_Western Black-headed Oriole
+Oriolus chinensis_Black-naped Oriole
+Oriolus chlorocephalus_Green-headed Oriole
+Oriolus cruentus_Javan Oriole
+Oriolus flavocinctus_Green Oriole
+Oriolus kundoo_Indian Golden Oriole
+Oriolus larvatus_African Black-headed Oriole
+Oriolus monacha_Ethiopian Black-headed Oriole
+Oriolus nigripennis_Black-winged Oriole
+Oriolus oriolus_Eurasian Golden Oriole
+Oriolus percivali_Black-tailed Oriole
+Oriolus phaeochromus_Halmahera Oriole
+Oriolus sagittatus_Olive-backed Oriole
+Oriolus steerii_Philippine Oriole
+Oriolus szalayi_Brown Oriole
+Oriolus tenuirostris_Slender-billed Oriole
+Oriolus traillii_Maroon Oriole
+Oriolus xanthonotus_Dark-throated Oriole
+Oriolus xanthornus_Black-hooded Oriole
+Oriturus superciliosus_Striped Sparrow
+Ornithion brunneicapillus_Brown-capped Tyrannulet
+Ornithion inerme_White-lored Tyrannulet
+Ornithion semiflavum_Yellow-bellied Tyrannulet
+Orocharis saltator_Jumping Bush Cricket
+Orochelidon flavipes_Pale-footed Swallow
+Orochelidon murina_Brown-bellied Swallow
+Ortalis araucuan_East Brazilian Chachalaca
+Ortalis canicollis_Chaco Chachalaca
+Ortalis cinereiceps_Grey-headed Chachalaca
+Ortalis columbiana_Colombian Chachalaca
+Ortalis erythroptera_Rufous-headed Chachalaca
+Ortalis garrula_Chestnut-winged Chachalaca
+Ortalis guttata_Speckled Chachalaca
+Ortalis leucogastra_White-bellied Chachalaca
+Ortalis motmot_Variable Chachalaca
+Ortalis poliocephala_West Mexican Chachalaca
+Ortalis ruficauda_Rufous-vented Chachalaca
+Ortalis squamata_Scaled Chachalaca
+Ortalis vetula_Plain Chachalaca
+Ortalis wagleri_Rufous-bellied Chachalaca
+Orthogonys chloricterus_Olive-green Tanager
+Orthonyx novaeguineae_Papuan Logrunner
+Orthonyx spaldingii_Chowchilla
+Orthonyx temminckii_Australian Logrunner
+Orthopsittaca manilatus_Red-bellied Macaw
+Orthotomus atrogularis_Dark-necked Tailorbird
+Orthotomus chaktomuk_Cambodian Tailorbird
+Orthotomus chloronotus_Green-backed Tailorbird
+Orthotomus derbianus_Grey-backed Tailorbird
+Orthotomus frontalis_Rufous-fronted Tailorbird
+Orthotomus nigriceps_White-browed Tailorbird
+Orthotomus ruficeps_Ashy Tailorbird
+Orthotomus sepium_Olive-backed Tailorbird
+Orthotomus sericeus_Rufous-tailed Tailorbird
+Orthotomus sutorius_Common Tailorbird
+Ortygornis pondicerianus_Grey Francolin
+Ortygornis sephaena_Crested Francolin
+Ortygospiza atricollis_Quailfinch
+Otidiphaps nobilis_Pheasant Pigeon
+Otocichla mupinensis_Chinese Thrush
+Otus bakkamoena_Indian Scops Owl
+Otus cyprius_Cyprus Scops Owl
+Otus elegans_Ryukyu Scops Owl
+Otus lempiji_Sunda Scops Owl
+Otus lettia_Collared Scops Owl
+Otus madagascariensis_Torotoroka Scops-Owl
+Otus magicus_Moluccan Scops Owl
+Otus manadensis_Sulawesi Scops Owl
+Otus mantananensis_Mantanani Scops Owl
+Otus pamelae_Arabian Scops Owl
+Otus rufescens_Reddish Scops Owl
+Otus rutilus_Madagascar Scops Owl
+Otus sagittatus_White-fronted Scops Owl
+Otus scops_Eurasian Scops Owl
+Otus semitorques_Japanese Scops Owl
+Otus senegalensis_African Scops Owl
+Otus spilocephalus_Mountain Scops Owl
+Otus sunia_Oriental Scops Owl
+Oxylabes madagascariensis_White-throated Oxylabes
+Oxyruncus cristatus_Sharpbill
+Oxyura ferruginea_Andean Duck
+Oxyura jamaicensis_Ruddy Duck
+Pachycare flavogriseum_Goldenface
+Pachycephala chlorura_Vanuatu Whistler
+Pachycephala cinerea_Mangrove Whistler
+Pachycephala flavifrons_Samoan Whistler
+Pachycephala fuliginosa_Western Whistler
+Pachycephala fulvotincta_Rusty-breasted Whistler
+Pachycephala griseonota_Drab Whistler
+Pachycephala homeyeri_White-vented Whistler
+Pachycephala hypoxantha_Bornean Whistler
+Pachycephala inornata_Gilbert's Whistler
+Pachycephala lanioides_White-breasted Whistler
+Pachycephala macrorhyncha_Yellow-throated Whistler
+Pachycephala mentalis_Black-chinned Whistler
+Pachycephala nudigula_Bare-throated Whistler
+Pachycephala olivacea_Olive Whistler
+Pachycephala orioloides_Oriole Whistler
+Pachycephala pectoralis_Golden Whistler
+Pachycephala philippinensis_Yellow-bellied Whistler
+Pachycephala rufiventris_Rufous Whistler
+Pachycephala schlegelii_Regent Whistler
+Pachycephala simplex_Grey Whistler
+Pachycephala soror_Sclater's Whistler
+Pachycephala sulfuriventer_Sulphur-bellied Whistler
+Pachycephala vitiensis_Fiji Whistler
+Pachyphantes superciliosus_Compact Weaver
+Pachyramphus aglaiae_Rose-throated Becard
+Pachyramphus albogriseus_Black-and-white Becard
+Pachyramphus castaneus_Chestnut-crowned Becard
+Pachyramphus cinnamomeus_Cinnamon Becard
+Pachyramphus homochrous_One-coloured Becard
+Pachyramphus major_Grey-collared Becard
+Pachyramphus marginatus_Black-capped Becard
+Pachyramphus minor_Pink-throated Becard
+Pachyramphus niger_Jamaican Becard
+Pachyramphus polychopterus_White-winged Becard
+Pachyramphus rufus_Cinereous Becard
+Pachyramphus surinamus_Glossy-backed Becard
+Pachyramphus validus_Crested Becard
+Pachyramphus versicolor_Barred Becard
+Pachyramphus viridis_Green-backed Becard
+Pachysylvia aurantiifrons_Golden-fronted Greenlet
+Pachysylvia decurtata_Lesser Greenlet
+Pachysylvia hypoxantha_Dusky-capped Greenlet
+Pachysylvia muscicapina_Buff-cheeked Greenlet
+Pachysylvia semibrunnea_Rufous-naped Greenlet
+Padda oryzivora_Java Sparrow
+Palmeria dolei_Akohekohe
+Pampa curvipennis_Wedge-tailed Sabrewing
+Pandion haliaetus_Osprey
+Panterpe insignis_Fiery-throated Hummingbird
+Panurus biarmicus_Bearded Tit
+Panyptila sanctihieronymi_Great Swallow-tailed Swift
+Parabuteo leucorrhous_White-rumped Hawk
+Parabuteo unicinctus_Harris's Hawk
+Paraclaravis mondetoura_Maroon-chested Ground Dove
+Paradisaea minor_Lesser Bird-of-Paradise
+Paradisaea rubra_Red Bird-of-Paradise
+Paradoxornis flavirostris_Black-breasted Parrotbill
+Paradoxornis guttaticollis_Spot-breasted Parrotbill
+Pardalotus punctatus_Spotted Pardalote
+Pardalotus rubricatus_Red-browed Pardalote
+Pardalotus striatus_Striated Pardalote
+Pardirallus maculatus_Spotted Rail
+Pardirallus nigricans_Blackish Rail
+Pardirallus sanguinolentus_Plumbeous Rail
+Parkerthraustes humeralis_Yellow-shouldered Grosbeak
+Parkesia motacilla_Louisiana Waterthrush
+Parkesia noveboracensis_Northern Waterthrush
+Paroaria capitata_Yellow-billed Cardinal
+Paroaria coronata_Red-crested Cardinal
+Paroaria dominicana_Red-cowled Cardinal
+Paroaria gularis_Red-capped Cardinal
+Paroreomyza montana_Maui Alauahio
+Parus cinereus_Cinereous Tit
+Parus major_Great Tit
+Parus minor_Japanese Tit
+Parus monticolus_Green-backed Tit
+Parvipsitta porphyrocephala_Purple-crowned Lorikeet
+Parvipsitta pusilla_Little Lorikeet
+Passer ammodendri_Saxaul Sparrow
+Passer cinnamomeus_Russet Sparrow
+Passer diffusus_Southern Grey-headed Sparrow
+Passer domesticus_House Sparrow
+Passer flaveolus_Plain-backed Sparrow
+Passer griseus_Northern Grey-headed Sparrow
+Passer hispaniolensis_Spanish Sparrow
+Passer italiae_Italian Sparrow
+Passer melanurus_Cape Sparrow
+Passer moabiticus_Dead Sea Sparrow
+Passer montanus_Eurasian Tree Sparrow
+Passer pyrrhonotus_Sind Sparrow
+Passer rufocinctus_Kenya Rufous Sparrow
+Passer simplex_Desert Sparrow
+Passer swainsonii_Swainson's Sparrow
+Passerculus sandwichensis_Savannah Sparrow
+Passerella iliaca_Fox Sparrow
+Passerina amoena_Lazuli Bunting
+Passerina caerulea_Blue Grosbeak
+Passerina ciris_Painted Bunting
+Passerina cyanea_Indigo Bunting
+Passerina leclancherii_Orange-breasted Bunting
+Passerina rositae_Rose-bellied Bunting
+Passerina versicolor_Varied Bunting
+Pastor roseus_Rose-coloured Starling
+Patagioenas araucana_Chilean Pigeon
+Patagioenas cayennensis_Pale-vented Pigeon
+Patagioenas corensis_Bare-eyed Pigeon
+Patagioenas fasciata_Band-tailed Pigeon
+Patagioenas flavirostris_Red-billed Pigeon
+Patagioenas goodsoni_Dusky Pigeon
+Patagioenas leucocephala_White-crowned Pigeon
+Patagioenas maculosa_Spot-winged Pigeon
+Patagioenas nigrirostris_Short-billed Pigeon
+Patagioenas picazuro_Picazuro Pigeon
+Patagioenas plumbea_Plumbeous Pigeon
+Patagioenas speciosa_Scaled Pigeon
+Patagioenas squamosa_Scaly-naped Pigeon
+Patagioenas subvinacea_Ruddy Pigeon
+Patagona gigas_Giant Hummingbird
+Pauxi pauxi_Helmeted Curassow
+Pavo cristatus_Indian Peafowl
+Pelargopsis amauroptera_Brown-winged Kingfisher
+Pelargopsis capensis_Stork-billed Kingfisher
+Pelecanus conspicillatus_Australian Pelican
+Pelecanus erythrorhynchos_American White Pelican
+Pelecanus occidentalis_Brown Pelican
+Pellorneum albiventre_Spot-throated Babbler
+Pellorneum bicolor_Ferruginous Babbler
+Pellorneum capistratum_Javan Black-capped Babbler
+Pellorneum celebense_Sulawesi Babbler
+Pellorneum fuscocapillus_Brown-capped Babbler
+Pellorneum malaccense_Short-tailed Babbler
+Pellorneum palustre_Marsh Babbler
+Pellorneum pyrrogenys_Temminck's Babbler
+Pellorneum rostratum_White-chested Babbler
+Pellorneum ruficeps_Puff-throated Babbler
+Pellorneum tickelli_Buff-breasted Babbler
+Peltops montanus_Mountain Peltops
+Penelope albipennis_White-winged Guan
+Penelope argyrotis_Band-tailed Guan
+Penelope barbata_Bearded Guan
+Penelope dabbenei_Red-faced Guan
+Penelope jacquacu_Spix's Guan
+Penelope marail_Marail Guan
+Penelope montagnii_Andean Guan
+Penelope obscura_Dusky-legged Guan
+Penelope perspicax_Cauca Guan
+Penelope purpurascens_Crested Guan
+Penelope superciliaris_Rusty-margined Guan
+Penelopides affinis_Mindanao Hornbill
+Penelopina nigra_Highland Guan
+Peneothello cyanus_Blue-gray Robin
+Peneothello sigillata_White-winged Robin
+Percnostola arenarum_Allpahuayo Antbird
+Percnostola rufifrons_Black-headed Antbird
+Perdicula argoondah_Rock Bush-Quail
+Perdicula asiatica_Jungle Bush-Quail
+Perdicula erythrorhyncha_Painted Bush-Quail
+Perdix perdix_Grey Partridge
+Pericrocotus cantonensis_Brown-rumped Minivet
+Pericrocotus cinnamomeus_Small Minivet
+Pericrocotus divaricatus_Ashy Minivet
+Pericrocotus erythropygius_White-bellied Minivet
+Pericrocotus ethologus_Long-tailed Minivet
+Pericrocotus flammeus_Orange Minivet
+Pericrocotus solaris_Grey-chinned Minivet
+Pericrocotus speciosus_Scarlet Minivet
+Pericrocotus tegimae_Ryukyu Minivet
+Periparus ater_Coal Tit
+Periparus elegans_Elegant Tit
+Periparus rubidiventris_Rufous-vented Tit
+Periparus rufonuchalis_Rufous-naped Tit
+Periparus venustulus_Yellow-bellied Tit
+Periporphyrus erythromelas_Red-and-black Grosbeak
+Perisoreus canadensis_Canada Jay
+Perisoreus infaustus_Siberian Jay
+Perissocephalus tricolor_Capuchinbird
+Pernis apivorus_European Honey-buzzard
+Pernis ptilorhynchus_Crested Honey-buzzard
+Petrochelidon ariel_Fairy Martin
+Petrochelidon fluvicola_Streak-throated Swallow
+Petrochelidon fulva_Cave Swallow
+Petrochelidon nigricans_Tree Martin
+Petrochelidon pyrrhonota_Cliff Swallow
+Petrochelidon spilodera_South African Swallow
+Petroica australis_South Island Robin
+Petroica boodang_Scarlet Robin
+Petroica goodenovii_Red-capped Robin
+Petroica longipes_North Island Robin
+Petroica macrocephala_Tomtit
+Petroica phoenicea_Flame Robin
+Petroica pusilla_Pacific Robin
+Petroica rodinogaster_Pink Robin
+Petroica rosea_Rose Robin
+Petronia petronia_Rock Sparrow
+Peucaea aestivalis_Bachman's Sparrow
+Peucaea botterii_Botteri's Sparrow
+Peucaea carpalis_Rufous-winged Sparrow
+Peucaea cassinii_Cassin's Sparrow
+Peucaea humeralis_Black-chested Sparrow
+Peucaea mystacalis_Bridled Sparrow
+Peucaea ruficauda_Stripe-headed Sparrow
+Peucaea sumichrasti_Cinnamon-tailed Sparrow
+Peucedramus taeniatus_Olive Warbler
+Pezopetes capitalis_Large-footed Finch
+Pezoporus wallicus_Ground Parrot
+Phacellodomus dorsalis_Chestnut-backed Thornbird
+Phacellodomus erythrophthalmus_Orange-eyed Thornbird
+Phacellodomus ferrugineigula_Orange-breasted Thornbird
+Phacellodomus maculipectus_Spot-breasted Thornbird
+Phacellodomus ruber_Greater Thornbird
+Phacellodomus rufifrons_Rufous-fronted Thornbird
+Phacellodomus sibilatrix_Little Thornbird
+Phacellodomus striaticeps_Streak-fronted Thornbird
+Phacellodomus striaticollis_Freckle-breasted Thornbird
+Phaenicophaeus sumatranus_Chestnut-bellied Malkoha
+Phaenicophaeus tristis_Green-billed Malkoha
+Phaenicophaeus viridirostris_Blue-faced Malkoha
+Phaenicophilus palmarum_Black-crowned Palm-Tanager
+Phaenostictus mcleannani_Ocellated Antbird
+Phaeochroa cuvierii_Scaly-breasted Hummingbird
+Phaeomyias murina_Mouse-colored Tyrannulet
+Phaethon aethereus_Red-billed Tropicbird
+Phaethon lepturus_White-tailed Tropicbird
+Phaethon rubricauda_Red-tailed Tropicbird
+Phaethornis atrimentalis_Black-throated Hermit
+Phaethornis bourcieri_Straight-billed Hermit
+Phaethornis eurynome_Scale-throated Hermit
+Phaethornis griseogularis_Grey-chinned Hermit
+Phaethornis guy_Green Hermit
+Phaethornis hispidus_White-bearded Hermit
+Phaethornis longirostris_Long-billed Hermit
+Phaethornis longuemareus_Little Hermit
+Phaethornis malaris_Great-billed Hermit
+Phaethornis nattereri_Cinnamon-throated Hermit
+Phaethornis pretrei_Planalto Hermit
+Phaethornis ruber_Reddish Hermit
+Phaethornis rupurumii_Streak-throated Hermit
+Phaethornis squalidus_Dusky-throated Hermit
+Phaethornis striigularis_Stripe-throated Hermit
+Phaethornis superciliosus_Long-tailed Hermit
+Phaethornis syrmatophorus_Tawny-bellied Hermit
+Phaethornis yaruqui_White-whiskered Hermit
+Phaetusa simplex_Large-billed Tern
+Phainopepla nitens_Phainopepla
+Phalacrocorax carbo_Great Cormorant
+Phalaenoptilus nuttallii_Common Poorwill
+Phalaropus fulicarius_Grey Phalarope
+Phalaropus lobatus_Red-necked Phalarope
+Phalaropus tricolor_Wilson's Phalarope
+Phapitreron amethystinus_Amethyst Brown-Dove
+Phapitreron leucotis_White-eared Brown-Dove
+Phaps chalcoptera_Common Bronzewing
+Phaps elegans_Brush Bronzewing
+Pharomachrus antisianus_Crested Quetzal
+Pharomachrus auriceps_Golden-headed Quetzal
+Pharomachrus fulgidus_White-tipped Quetzal
+Pharomachrus mocinno_Resplendent Quetzal
+Pharomachrus pavoninus_Pavonine Quetzal
+Phasianus colchicus_Common Pheasant
+Phedina borbonica_Mascarene Martin
+Phegornis mitchellii_Diademed Sandpiper-Plover
+Phelpsia inornata_White-bearded Flycatcher
+Pheucticus aureoventris_Black-backed Grosbeak
+Pheucticus chrysogaster_Golden Grosbeak
+Pheucticus chrysopeplus_Yellow Grosbeak
+Pheucticus ludovicianus_Rose-breasted Grosbeak
+Pheucticus melanocephalus_Black-headed Grosbeak
+Pheucticus tibialis_Black-thighed Grosbeak
+Pheugopedius atrogularis_Black-throated Wren
+Pheugopedius coraya_Coraya Wren
+Pheugopedius eisenmanni_Inca Wren
+Pheugopedius euophrys_Plain-tailed Wren
+Pheugopedius fasciatoventris_Black-bellied Wren
+Pheugopedius felix_Happy Wren
+Pheugopedius genibarbis_Moustached Wren
+Pheugopedius maculipectus_Spot-breasted Wren
+Pheugopedius mystacalis_Whiskered Wren
+Pheugopedius rutilus_Rufous-breasted Wren
+Pheugopedius sclateri_Speckle-breasted Wren
+Pheugopedius spadix_Sooty-headed Wren
+Philemon buceroides_Helmeted Friarbird
+Philemon citreogularis_Little Friarbird
+Philemon corniculatus_Noisy Friarbird
+Philentoma pyrhoptera_Rufous-winged Philentoma
+Philentoma velata_Maroon-breasted Philentoma
+Philepitta schlegeli_Schlegel's Asity
+Philesturnus rufusater_North Island Saddleback
+Philetairus socius_Sociable Weaver
+Philortyx fasciatus_Banded Quail
+Philydor atricapillus_Black-capped Foliage-gleaner
+Philydor erythrocercum_Rufous-rumped Foliage-gleaner
+Philydor fuscipenne_Slaty-winged Foliage-gleaner
+Philydor pyrrhodes_Cinnamon-rumped Foliage-gleaner
+Phimosus infuscatus_Bare-faced Ibis
+Phlegopsis erythroptera_Reddish-winged Bare-eye
+Phlegopsis nigromaculata_Black-spotted Bare-eye
+Phleocryptes melanops_Wren-like Rushbird
+Phlogophilus hemileucurus_Ecuadorian Piedtail
+Phodilus assimilis_Sri Lanka Bay-Owl
+Phodilus badius_Oriental Bay-Owl
+Phoebastria immutabilis_Laysan Albatross
+Phoebastria nigripes_Black-footed Albatross
+Phoenicircus carnifex_Guianan Red-Cotinga
+Phoenicircus nigricollis_Black-necked Red-Cotinga
+Phoeniconaias minor_Lesser Flamingo
+Phoenicoparrus andinus_Andean Flamingo
+Phoenicoparrus jamesi_James's Flamingo
+Phoenicopterus chilensis_Chilean Flamingo
+Phoenicopterus roseus_Greater Flamingo
+Phoenicopterus ruber_American Flamingo
+Phoeniculus bollei_White-headed Woodhoopoe
+Phoeniculus purpureus_Green Woodhoopoe
+Phoenicurus auroreus_Daurian Redstart
+Phoenicurus frontalis_Blue-fronted Redstart
+Phoenicurus fuliginosus_Plumbeous Redstart
+Phoenicurus hodgsoni_Hodgson's Redstart
+Phoenicurus leucocephalus_White-capped Redstart
+Phoenicurus moussieri_Moussier's Redstart
+Phoenicurus ochruros_Black Redstart
+Phoenicurus phoenicurus_Common Redstart
+Pholia sharpii_Sharpe's Starling
+Phonygammus keraudrenii_Trumpet Manucode
+Phragmacia substriata_Namaqua Warbler
+Phrygilus atriceps_Black-hooded Sierra Finch
+Phrygilus gayi_Grey-hooded Sierra Finch
+Phrygilus patagonicus_Patagonian Sierra Finch
+Phylidonyris niger_White-cheeked Honeyeater
+Phylidonyris novaehollandiae_New Holland Honeyeater
+Phylidonyris pyrrhopterus_Crescent Honeyeater
+Phyllastrephus cabanisi_Cabanis's Greenbul
+Phyllastrephus cerviniventris_Grey-olive Greenbul
+Phyllastrephus fischeri_Fischer's Greenbul
+Phyllastrephus flavostriatus_Yellow-streaked Greenbul
+Phyllastrephus strepitans_Northern Brownbul
+Phyllastrephus terrestris_Terrestrial Brownbul
+Phyllergates cucullatus_Mountain Tailorbird
+Phyllergates heterolaemus_Rufous-headed Tailorbird
+Phyllolais pulchella_Buff-bellied Warbler
+Phyllomyias burmeisteri_Rough-legged Tyrannulet
+Phyllomyias cinereiceps_Ashy-headed Tyrannulet
+Phyllomyias fasciatus_Planalto Tyrannulet
+Phyllomyias griseiceps_Sooty-headed Tyrannulet
+Phyllomyias griseocapilla_Grey-capped Tyrannulet
+Phyllomyias nigrocapillus_Black-capped Tyrannulet
+Phyllomyias plumbeiceps_Plumbeous-crowned Tyrannulet
+Phyllomyias sclateri_Sclater's Tyrannulet
+Phyllomyias uropygialis_Tawny-rumped Tyrannulet
+Phyllomyias virescens_Greenish Tyrannulet
+Phyllopalpus pulchellus_Handsome Trig
+Phylloscartes ceciliae_Alagoas Tyrannulet
+Phylloscartes difficilis_Serra do Mar Tyrannulet
+Phylloscartes eximius_Southern Bristle-Tyrant
+Phylloscartes gualaquizae_Ecuadorian Tyrannulet
+Phylloscartes kronei_Restinga Tyrannulet
+Phylloscartes lanyoni_Antioquia Bristle-Tyrant
+Phylloscartes ophthalmicus_Marble-faced Bristle-Tyrant
+Phylloscartes oustaleti_Oustalet's Tyrannulet
+Phylloscartes parkeri_Cinnamon-faced Tyrannulet
+Phylloscartes paulista_Sao Paulo Tyrannulet
+Phylloscartes poecilotis_Variegated Bristle-Tyrant
+Phylloscartes roquettei_Minas Gerais Tyrannulet
+Phylloscartes superciliaris_Rufous-browed Tyrannulet
+Phylloscartes sylviolus_Bay-ringed Tyrannulet
+Phylloscartes ventralis_Mottle-cheeked Tyrannulet
+Phylloscartes virescens_Olive-green Tyrannulet
+Phylloscopus affinis_Tickell's Leaf Warbler
+Phylloscopus armandii_Yellow-streaked Warbler
+Phylloscopus bonelli_Western Bonelli's Warbler
+Phylloscopus borealis_Arctic Warbler
+Phylloscopus borealoides_Sakhalin Leaf Warbler
+Phylloscopus budongoensis_Uganda Woodland-Warbler
+Phylloscopus burkii_Green-crowned Warbler
+Phylloscopus calciatilis_Limestone Leaf Warbler
+Phylloscopus cantator_Yellow-vented Warbler
+Phylloscopus castaniceps_Chestnut-crowned Warbler
+Phylloscopus chloronotus_Lemon-rumped Warbler
+Phylloscopus claudiae_Claudia's Leaf Warbler
+Phylloscopus collybita_Common Chiffchaff
+Phylloscopus coronatus_Eastern Crowned Warbler
+Phylloscopus emeiensis_Emei Leaf Warbler
+Phylloscopus examinandus_Kamchatka Leaf Warbler
+Phylloscopus forresti_Sichuan Leaf Warbler
+Phylloscopus fuligiventer_Smoky Warbler
+Phylloscopus fuscatus_Dusky Warbler
+Phylloscopus goodsoni_Hartert's Leaf Warbler
+Phylloscopus grammiceps_Sunda Warbler
+Phylloscopus griseolus_Sulphur-bellied Warbler
+Phylloscopus humei_Hume's Warbler
+Phylloscopus ibericus_Iberian Chiffchaff
+Phylloscopus ijimae_Ijima's Leaf Warbler
+Phylloscopus inornatus_Yellow-browed Warbler
+Phylloscopus intensior_Davison's Leaf Warbler
+Phylloscopus intermedius_White-spectacled Warbler
+Phylloscopus kansuensis_Gansu Leaf Warbler
+Phylloscopus maculipennis_Ashy-throated Warbler
+Phylloscopus magnirostris_Large-billed Leaf Warbler
+Phylloscopus montis_Yellow-breasted Warbler
+Phylloscopus neglectus_Plain Leaf Warbler
+Phylloscopus nitidus_Green Warbler
+Phylloscopus occipitalis_Western Crowned Warbler
+Phylloscopus occisinensis_Alpine Leaf Warbler
+Phylloscopus ogilviegranti_Kloss's Leaf Warbler
+Phylloscopus olivaceus_Philippine Leaf Warbler
+Phylloscopus omeiensis_Martens's Warbler
+Phylloscopus orientalis_Eastern Bonelli's Warbler
+Phylloscopus plumbeitarsus_Two-barred Warbler
+Phylloscopus poliocephalus_Island Leaf Warbler
+Phylloscopus poliogenys_Grey-cheeked Warbler
+Phylloscopus proregulus_Pallas's Warbler
+Phylloscopus pulcher_Buff-barred Warbler
+Phylloscopus reguloides_Blyth's Leaf Warbler
+Phylloscopus ruficapilla_Yellow-throated Woodland-Warbler
+Phylloscopus sarasinorum_Lompobattang Leaf Warbler
+Phylloscopus schwarzi_Radde's Warbler
+Phylloscopus sibilatrix_Wood Warbler
+Phylloscopus sindianus_Mountain Chiffchaff
+Phylloscopus soror_Alström's Warbler
+Phylloscopus subaffinis_Buff-throated Warbler
+Phylloscopus subviridis_Brooks's Leaf Warbler
+Phylloscopus tenellipes_Pale-legged Leaf Warbler
+Phylloscopus tephrocephalus_Grey-crowned Warbler
+Phylloscopus trivirgatus_Mountain Leaf Warbler
+Phylloscopus trochiloides_Greenish Warbler
+Phylloscopus trochilus_Willow Warbler
+Phylloscopus tytleri_Tytler's Leaf Warbler
+Phylloscopus umbrovirens_Brown Woodland-Warbler
+Phylloscopus valentini_Bianchi's Warbler
+Phylloscopus whistleri_Whistler's Warbler
+Phylloscopus xanthodryas_Japanese Leaf Warbler
+Phylloscopus xanthoschistos_Grey-hooded Warbler
+Phylloscopus yunnanensis_Chinese Leaf Warbler
+Phytotoma raimondii_Peruvian Plantcutter
+Phytotoma rara_Rufous-tailed Plantcutter
+Phytotoma rutila_White-tipped Plantcutter
+Piaya cayana_Squirrel Cuckoo
+Piaya melanogaster_Black-bellied Cuckoo
+Pica bottanensis_Black-rumped Magpie
+Pica hudsonia_Black-billed Magpie
+Pica nuttalli_Yellow-billed Magpie
+Pica pica_Common Magpie
+Pica serica_Oriental Magpie
+Picoides arcticus_Black-backed Woodpecker
+Picoides dorsalis_American Three-toed Woodpecker
+Picoides tridactylus_Eurasian Three-toed Woodpecker
+Piculus aurulentus_White-browed Woodpecker
+Piculus callopterus_Stripe-cheeked Woodpecker
+Piculus chrysochloros_Golden-green Woodpecker
+Piculus flavigula_Yellow-throated Woodpecker
+Piculus leucolaemus_White-throated Woodpecker
+Picumnus albosquamatus_White-wedged Piculet
+Picumnus aurifrons_Bar-breasted Piculet
+Picumnus cinnamomeus_Chestnut Piculet
+Picumnus cirratus_White-barred Piculet
+Picumnus dorbignyanus_Ocellated Piculet
+Picumnus exilis_Golden-spangled Piculet
+Picumnus granadensis_Greyish Piculet
+Picumnus innominatus_Speckled Piculet
+Picumnus lafresnayi_Lafresnaye's Piculet
+Picumnus limae_Ochraceous Piculet
+Picumnus nebulosus_Mottled Piculet
+Picumnus olivaceus_Olivaceous Piculet
+Picumnus pygmaeus_Spotted Piculet
+Picumnus rufiventris_Rufous-breasted Piculet
+Picumnus sclateri_Ecuadorian Piculet
+Picumnus spilogaster_White-bellied Piculet
+Picumnus squamulatus_Scaled Piculet
+Picumnus temminckii_Ochre-collared Piculet
+Picus awokera_Japanese Woodpecker
+Picus canus_Grey-headed Woodpecker
+Picus chlorolophus_Lesser Yellownape
+Picus erythropygius_Black-headed Woodpecker
+Picus puniceus_Crimson-winged Woodpecker
+Picus sharpei_Iberian Green Woodpecker
+Picus squamatus_Scaly-bellied Woodpecker
+Picus vaillantii_Levaillant's Woodpecker
+Picus viridis_Eurasian Green Woodpecker
+Picus vittatus_Laced Woodpecker
+Picus xanthopygaeus_Streak-throated Woodpecker
+Pinicola enucleator_Pine Grosbeak
+Pionites leucogaster_White-bellied Parrot
+Pionites melanocephalus_Black-headed Parrot
+Pionopsitta pileata_Pileated Parrot
+Pionus chalcopterus_Bronze-winged Parrot
+Pionus fuscus_Dusky Parrot
+Pionus maximiliani_Scaly-headed Parrot
+Pionus menstruus_Blue-headed Parrot
+Pionus senilis_White-crowned Parrot
+Pionus sordidus_Red-billed Parrot
+Pionus tumultuosus_Speckle-faced Parrot
+Pipile cujubi_Red-throated Piping-Guan
+Pipile cumanensis_Blue-throated Piping-Guan
+Pipilo chlorurus_Green-tailed Towhee
+Pipilo erythrophthalmus_Eastern Towhee
+Pipilo maculatus_Spotted Towhee
+Pipilo ocai_Collared Towhee
+Pipra aureola_Crimson-hooded Manakin
+Pipra fasciicauda_Band-tailed Manakin
+Pipra filicauda_Wire-tailed Manakin
+Pipraeidea melanonota_Fawn-breasted Tanager
+Pipreola arcuata_Barred Fruiteater
+Pipreola aureopectus_Golden-breasted Fruiteater
+Pipreola formosa_Handsome Fruiteater
+Pipreola frontalis_Scarlet-breasted Fruiteater
+Pipreola intermedia_Band-tailed Fruiteater
+Pipreola jucunda_Orange-breasted Fruiteater
+Pipreola lubomirskii_Black-chested Fruiteater
+Pipreola riefferii_Green-and-black Fruiteater
+Pipreola whitelyi_Red-banded Fruiteater
+Piprites chloris_Wing-barred Piprites
+Piprites griseiceps_Grey-headed Piprites
+Piprites pileata_Black-capped Piprites
+Piranga bidentata_Flame-coloured Tanager
+Piranga erythrocephala_Red-headed Tanager
+Piranga flava_Hepatic Tanager
+Piranga leucoptera_White-winged Tanager
+Piranga ludoviciana_Western Tanager
+Piranga olivacea_Scarlet Tanager
+Piranga roseogularis_Rose-throated Tanager
+Piranga rubra_Summer Tanager
+Piranga rubriceps_Red-hooded Tanager
+Pitangus lictor_Lesser Kiskadee
+Pitangus sulphuratus_Great Kiskadee
+Pithecophaga jefferyi_Philippine Eagle
+Pithys albifrons_White-plumed Antbird
+Pitohui kirhocephalus_Northern Variable Pitohui
+Pitta brachyura_Indian Pitta
+Pitta elegans_Elegant Pitta
+Pitta maxima_Ivory-breasted Pitta
+Pitta megarhyncha_Mangrove Pitta
+Pitta moluccensis_Blue-winged Pitta
+Pitta nympha_Fairy Pitta
+Pitta sordida_Western Hooded Pitta
+Pitta steerii_Azure-breasted Pitta
+Pitta versicolor_Noisy Pitta
+Pittasoma michleri_Black-crowned Antpitta
+Pittasoma rufopileatum_Rufous-crowned Antpitta
+Pityriasis gymnocephala_Bornean Bristlehead
+Platalea ajaja_Roseate Spoonbill
+Platalea leucorodia_Eurasian Spoonbill
+Platycercus adscitus_Pale-headed Rosella
+Platycercus caledonicus_Green Rosella
+Platycercus elegans_Crimson Rosella
+Platycercus eximius_Eastern Rosella
+Platylophus galericulatus_Crested Jayshrike
+Platyrinchus cancrominus_Stub-tailed Spadebill
+Platyrinchus coronatus_Golden-crowned Spadebill
+Platyrinchus flavigularis_Yellow-throated Spadebill
+Platyrinchus leucoryphus_Russet-winged Spadebill
+Platyrinchus mystaceus_White-throated Spadebill
+Platyrinchus platyrhynchos_White-crested Spadebill
+Platyrinchus saturatus_Cinnamon-crested Spadebill
+Platysmurus leucopterus_Black Magpie
+Platysteira blissetti_Red-cheeked Wattle-eye
+Platysteira castanea_Chestnut Wattle-eye
+Platysteira concreta_Yellow-bellied Wattle-eye
+Platysteira cyanea_Brown-throated Wattle-eye
+Platysteira peltata_Black-throated Wattle-eye
+Plectorhyncha lanceolata_Striped Honeyeater
+Plectrophenax hyperboreus_McKay's Bunting
+Plectrophenax nivalis_Snow Bunting
+Plegadis chihi_White-faced Ibis
+Plegadis falcinellus_Glossy Ibis
+Plegadis ridgwayi_Puna Ibis
+Plocepasser mahali_White-browed Sparrow-Weaver
+Plocepasser superciliosus_Chestnut-crowned Sparrow-Weaver
+Ploceus baglafecht_Baglafecht Weaver
+Ploceus bicolor_Forest Weaver
+Ploceus capensis_Cape Weaver
+Ploceus cucullatus_Village Weaver
+Ploceus galbula_Rüppell's Weaver
+Ploceus hypoxanthus_Asian Golden Weaver
+Ploceus intermedius_Lesser Masked-Weaver
+Ploceus jacksoni_Golden-backed Weaver
+Ploceus luteolus_Little Weaver
+Ploceus manyar_Streaked Weaver
+Ploceus melanocephalus_Black-headed Weaver
+Ploceus nelicourvi_Nelicourvi Weaver
+Ploceus nigerrimus_Vieillot's Black Weaver
+Ploceus nigricollis_Black-necked Weaver
+Ploceus ocularis_Spectacled Weaver
+Ploceus philippinus_Baya Weaver
+Ploceus sakalava_Sakalava Weaver
+Ploceus spekei_Speke's Weaver
+Ploceus subaureus_African Golden-Weaver
+Ploceus velatus_Southern Masked-Weaver
+Ploceus vitellinus_Vitelline Masked-Weaver
+Ploceus xanthops_Holub's Golden-Weaver
+Ploceus xanthopterus_Southern Brown-throated Weaver
+Pluvialis apricaria_European Golden Plover
+Pluvialis dominica_American Golden Plover
+Pluvialis fulva_Pacific Golden Plover
+Pluvialis squatarola_Grey Plover
+Pnoepyga albiventer_Scaly-breasted Cupwing
+Pnoepyga formosana_Taiwan Cupwing
+Pnoepyga immaculata_Immaculate Cupwing
+Pnoepyga pusilla_Pygmy Cupwing
+Podargus ocellatus_Marbled Frogmouth
+Podargus strigoides_Tawny Frogmouth
+Podiceps auritus_Slavonian Grebe
+Podiceps cristatus_Great Crested Grebe
+Podiceps gallardoi_Hooded Grebe
+Podiceps grisegena_Red-necked Grebe
+Podiceps major_Great Grebe
+Podiceps nigricollis_Black-necked Grebe
+Podiceps occipitalis_Silvery Grebe
+Podilymbus podiceps_Pied-billed Grebe
+Podoces hendersoni_Mongolian Ground-Jay
+Poecile atricapillus_Black-capped Chickadee
+Poecile carolinensis_Carolina Chickadee
+Poecile cinctus_Siberian Tit
+Poecile gambeli_Mountain Chickadee
+Poecile hudsonicus_Boreal Chickadee
+Poecile lugubris_Sombre Tit
+Poecile montanus_Willow Tit
+Poecile palustris_Marsh Tit
+Poecile rufescens_Chestnut-backed Chickadee
+Poecile sclateri_Mexican Chickadee
+Poecile weigoldicus_Sichuan Tit
+Poecilodryas hypoleuca_Black-sided Robin
+Poecilostreptus cabanisi_Azure-rumped Tanager
+Poecilostreptus palmeri_Grey-and-gold Tanager
+Poecilotriccus albifacies_White-cheeked Tody-Flycatcher
+Poecilotriccus calopterus_Golden-winged Tody-Flycatcher
+Poecilotriccus capitalis_Black-and-white Tody-Flycatcher
+Poecilotriccus fumifrons_Smoky-fronted Tody-Flycatcher
+Poecilotriccus latirostris_Rusty-fronted Tody-Flycatcher
+Poecilotriccus luluae_Johnson's Tody-Flycatcher
+Poecilotriccus plumbeiceps_Ochre-faced Tody-Flycatcher
+Poecilotriccus ruficeps_Rufous-crowned Tody-Flycatcher
+Poecilotriccus russatus_Ruddy Tody-Flycatcher
+Poecilotriccus sylvia_Slate-headed Tody-Flycatcher
+Pogoniulus atroflavus_Red-rumped Tinkerbird
+Pogoniulus bilineatus_Yellow-rumped Tinkerbird
+Pogoniulus chrysoconus_Yellow-fronted Tinkerbird
+Pogoniulus leucomystax_Moustached Tinkerbird
+Pogoniulus pusillus_Red-fronted Tinkerbird
+Pogoniulus scolopaceus_Speckled Tinkerbird
+Pogoniulus simplex_Green Tinkerbird
+Pogoniulus subsulphureus_Yellow-throated Tinkerbird
+Pogonocichla stellata_White-starred Robin
+Poicephalus cryptoxanthus_Brown-headed Parrot
+Poicephalus fuscicollis_Brown-necked Parrot
+Poicephalus meyeri_Meyer's Parrot
+Poicephalus robustus_Cape Parrot
+Poicephalus rufiventris_Red-bellied Parrot
+Poicephalus senegalus_Senegal Parrot
+Poliocrania exsul_Chestnut-backed Antbird
+Poliolimnas cinereus_White-browed Crake
+Polioptila albiloris_White-lored Gnatcatcher
+Polioptila bilineata_White-browed Gnatcatcher
+Polioptila caerulea_Blue-grey Gnatcatcher
+Polioptila californica_California Gnatcatcher
+Polioptila dumicola_Masked Gnatcatcher
+Polioptila lactea_Creamy-bellied Gnatcatcher
+Polioptila lembeyei_Cuban Gnatcatcher
+Polioptila melanura_Black-tailed Gnatcatcher
+Polioptila nigriceps_Black-capped Gnatcatcher
+Polioptila plumbea_Tropical Gnatcatcher
+Polioptila schistaceigula_Slate-throated Gnatcatcher
+Polyboroides typus_African Harrier-Hawk
+Polyerata amabilis_Blue-chested Hummingbird
+Polyerata decora_Charming Hummingbird
+Polyplectron bicalcaratum_Grey Peacock-Pheasant
+Polyplectron chalcurum_Bronze-tailed Peacock-Pheasant
+Polyplectron germaini_Germain's Peacock-Pheasant
+Polyplectron malacense_Malayan Peacock-Pheasant
+Polystictus pectoralis_Bearded Tachuri
+Polystictus superciliaris_Grey-backed Tachuri
+Polytelis anthopeplus_Regent Parrot
+Polytelis swainsonii_Superb Parrot
+Polytmus guainumbi_White-tailed Goldenthroat
+Polytmus theresiae_Green-tailed Goldenthroat
+Pomatorhinus ferruginosus_Black-crowned Scimitar-Babbler
+Pomatorhinus horsfieldii_Indian Scimitar-Babbler
+Pomatorhinus melanurus_Sri Lanka Scimitar-Babbler
+Pomatorhinus montanus_Javan Scimitar-Babbler
+Pomatorhinus musicus_Taiwan Scimitar-Babbler
+Pomatorhinus ochraceiceps_Red-billed Scimitar-Babbler
+Pomatorhinus ruficollis_Streak-breasted Scimitar-Babbler
+Pomatorhinus schisticeps_White-browed Scimitar-Babbler
+Pomatorhinus superciliaris_Slender-billed Scimitar-Babbler
+Pomatostomus ruficeps_Chestnut-crowned Babbler
+Pomatostomus superciliosus_White-browed Babbler
+Pomatostomus temporalis_Grey-crowned Babbler
+Poodytes gramineus_Little Grassbird
+Poodytes punctatus_New Zealand Fernbird
+Pooecetes gramineus_Vesper Sparrow
+Poospiza nigrorufa_Black-and-rufous Warbling Finch
+Porphyrio flavirostris_Azure Gallinule
+Porphyrio madagascariensis_African Swamphen
+Porphyrio martinica_Purple Gallinule
+Porphyrio melanotus_Australasian Swamphen
+Porphyrio poliocephalus_Grey-headed Swamphen
+Porphyrio porphyrio_Western Swamphen
+Porphyriops melanops_Spot-flanked Gallinule
+Porzana carolina_Sora
+Porzana porzana_Spotted Crake
+Porzana spiloptera_Dot-winged Crake
+Power tools_Power tools
+Premnoplex brunnescens_Spotted Barbtail
+Premnornis guttuliger_Rusty-winged Barbtail
+Primolius auricollis_Yellow-collared Macaw
+Primolius couloni_Blue-headed Macaw
+Primolius maracana_Blue-winged Macaw
+Prinia atrogularis_Black-throated Prinia
+Prinia bairdii_Banded Prinia
+Prinia buchanani_Rufous-fronted Prinia
+Prinia crinigera_Himalayan Prinia
+Prinia erythroptera_Red-winged Prinia
+Prinia familiaris_Bar-winged Prinia
+Prinia flavicans_Black-chested Prinia
+Prinia flaviventris_Yellow-bellied Prinia
+Prinia gracilis_Graceful Prinia
+Prinia hodgsonii_Grey-breasted Prinia
+Prinia hypoxantha_Drakensberg Prinia
+Prinia inornata_Plain Prinia
+Prinia lepida_Delicate Prinia
+Prinia maculosa_Karoo Prinia
+Prinia polychroa_Brown Prinia
+Prinia rufescens_Rufescent Prinia
+Prinia rufifrons_Red-fronted Prinia
+Prinia socialis_Ashy Prinia
+Prinia striata_Striped Prinia
+Prinia subflava_Tawny-flanked Prinia
+Prinia superciliaris_Hill Prinia
+Prinia sylvatica_Jungle Prinia
+Prionochilus maculatus_Yellow-breasted Flowerpecker
+Prionochilus thoracicus_Scarlet-breasted Flowerpecker
+Prionochilus xanthopygius_Yellow-rumped Flowerpecker
+Prionops plumatus_White Helmetshrike
+Prionops retzii_Retz's Helmetshrike
+Priotelus roseigaster_Hispaniolan Trogon
+Priotelus temnurus_Cuban Trogon
+Probosciger aterrimus_Palm Cockatoo
+Procarduelis nipalensis_Dark-breasted Rosefinch
+Procnias albus_White Bellbird
+Procnias averano_Bearded Bellbird
+Procnias nudicollis_Bare-throated Bellbird
+Procnias tricarunculatus_Three-wattled Bellbird
+Progne chalybea_Grey-breasted Martin
+Progne elegans_Southern Martin
+Progne subis_Purple Martin
+Progne tapera_Brown-chested Martin
+Promerops cafer_Cape Sugarbird
+Prosopeia personata_Masked Shining-Parrot
+Prosopeia tabuensis_Red Shining-Parrot
+Prosthemadera novaeseelandiae_Tui
+Protonotaria citrea_Prothonotary Warbler
+Prunella collaris_Alpine Accentor
+Prunella fulvescens_Brown Accentor
+Prunella modularis_Dunnock
+Prunella montanella_Siberian Accentor
+Prunella ocularis_Radde's Accentor
+Prunella rubeculoides_Robin Accentor
+Prunella strophiata_Rufous-breasted Accentor
+Psalidoprocne pristoptera_Black Sawwing
+Psaltriparus minimus_Bushtit
+Psarisomus dalhousiae_Long-tailed Broadbill
+Psarocolius angustifrons_Russet-backed Oropendola
+Psarocolius atrovirens_Dusky-green Oropendola
+Psarocolius bifasciatus_Olive Oropendola
+Psarocolius decumanus_Crested Oropendola
+Psarocolius montezuma_Montezuma Oropendola
+Psarocolius viridis_Green Oropendola
+Psarocolius wagleri_Chestnut-headed Oropendola
+Psephotus haematonotus_Red-rumped Parrot
+Psephotus varius_Mulga Parrot
+Pseudacris brimleyi_Brimley's Chorus Frog
+Pseudacris clarkii_Spotted Chorus Frog
+Pseudacris crucifer_Spring Peeper
+Pseudacris feriarum_Upland Chorus Frog
+Pseudacris nigrita_Southern Chorus Frog
+Pseudacris ocularis_Little Grass Frog
+Pseudacris ornata_Ornate Chorus Frog
+Pseudacris streckeri_Strecker's Chorus Frog
+Pseudacris triseriata_Striped Chorus Frog
+Pseudasthenes humicola_Dusky-tailed Canastero
+Pseudastur albicollis_White Hawk
+Pseudastur occidentalis_Grey-backed Hawk
+Pseudelaenia leucospodia_Grey-and-white Tyrannulet
+Pseudeos cardinalis_Cardinal Lory
+Pseudibis papillosa_Red-naped Ibis
+Pseudocolaptes boissonneautii_Streaked Tuftedcheek
+Pseudocolaptes lawrencii_Buffy Tuftedcheek
+Pseudocolopteryx citreola_Ticking Doradito
+Pseudocolopteryx dinelliana_Dinelli's Doradito
+Pseudocolopteryx flaviventris_Warbling Doradito
+Pseudocolopteryx sclateri_Crested Doradito
+Pseudoleistes guirahuro_Yellow-rumped Marshbird
+Pseudoleistes virescens_Brown-and-yellow Marshbird
+Pseudonestor xanthophrys_Maui Parrotbill
+Pseudonigrita arnaudi_Grey-headed Social-Weaver
+Pseudopipra pipra_White-crowned Manakin
+Pseudopodoces humilis_Ground Tit
+Pseudorectes ferrugineus_Rusty Pitohui
+Pseudoseisura cristata_Caatinga Cacholote
+Pseudoseisura gutturalis_White-throated Cacholote
+Pseudoseisura lophotes_Brown Cacholote
+Pseudoseisura unirufa_Rufous Cacholote
+Pseudospingus verticalis_Black-headed Hemispingus
+Pseudotriccus pelzelni_Bronze-olive Pygmy-Tyrant
+Pseudotriccus ruficeps_Rufous-headed Pygmy-Tyrant
+Psilopogon annamensis_Indochinese Barbet
+Psilopogon armillaris_Flame-fronted Barbet
+Psilopogon asiaticus_Blue-throated Barbet
+Psilopogon auricularis_Necklaced Barbet
+Psilopogon australis_Yellow-eared Barbet
+Psilopogon chrysopogon_Gold-whiskered Barbet
+Psilopogon corvinus_Brown-throated Barbet
+Psilopogon duvaucelii_Black-eared Barbet
+Psilopogon eximius_Bornean Barbet
+Psilopogon faber_Chinese Barbet
+Psilopogon faiostrictus_Green-eared Barbet
+Psilopogon flavifrons_Yellow-fronted Barbet
+Psilopogon franklinii_Golden-throated Barbet
+Psilopogon haemacephalus_Coppersmith Barbet
+Psilopogon henricii_Yellow-crowned Barbet
+Psilopogon incognitus_Moustached Barbet
+Psilopogon lagrandieri_Red-vented Barbet
+Psilopogon lineatus_Lineated Barbet
+Psilopogon malabaricus_Malabar Barbet
+Psilopogon monticola_Mountain Barbet
+Psilopogon mystacophanos_Red-throated Barbet
+Psilopogon nuchalis_Taiwan Barbet
+Psilopogon oorti_Black-browed Barbet
+Psilopogon pulcherrimus_Golden-naped Barbet
+Psilopogon pyrolophus_Fire-tufted Barbet
+Psilopogon rafflesii_Red-crowned Barbet
+Psilopogon rubricapillus_Crimson-fronted Barbet
+Psilopogon virens_Great Barbet
+Psilopogon viridis_White-cheeked Barbet
+Psilopogon zeylanicus_Brown-headed Barbet
+Psilopsiagon aurifrons_Mountain Parakeet
+Psilopsiagon aymara_Grey-hooded Parakeet
+Psilorhamphus guttatus_Spotted Bamboowren
+Psilorhinus morio_Brown Jay
+Psiloscops flammeolus_Flammulated Owl
+Psittacara erythrogenys_Red-masked Parakeet
+Psittacara finschi_Crimson-fronted Parakeet
+Psittacara holochlorus_Green Parakeet
+Psittacara leucophthalmus_White-eyed Parakeet
+Psittacara mitratus_Mitred Parakeet
+Psittacara strenuus_Pacific Parakeet
+Psittacara wagleri_Scarlet-fronted Parakeet
+Psittacula alexandri_Red-breasted Parakeet
+Psittacula calthrapae_Layard's Parakeet
+Psittacula columboides_Malabar Parakeet
+Psittacula cyanocephala_Plum-headed Parakeet
+Psittacula eques_Echo Parakeet
+Psittacula eupatria_Alexandrine Parakeet
+Psittacula finschii_Grey-headed Parakeet
+Psittacula himalayana_Slaty-headed Parakeet
+Psittacula krameri_Ring-necked Parakeet
+Psittacula longicauda_Long-tailed Parakeet
+Psittacus erithacus_Grey Parrot
+Psittinus cyanurus_Blue-rumped Parrot
+Psittiparus gularis_Grey-headed Parrotbill
+Psophia crepitans_Grey-winged Trumpeter
+Psophia leucoptera_Pale-winged Trumpeter
+Psophia viridis_Dark-winged Trumpeter
+Psophocichla litsitsirupa_Groundscraper Thrush
+Psophodes cristatus_Chirruping Wedgebill
+Psophodes nigrogularis_Western Whipbird
+Psophodes occidentalis_Chiming Wedgebill
+Psophodes olivaceus_Eastern Whipbird
+Pteridophora alberti_King-of-Saxony Bird-of-Paradise
+Pternistis adspersus_Red-billed Spurfowl
+Pternistis afer_Red-necked Spurfowl
+Pternistis ahantensis_Ahanta Spurfowl
+Pternistis bicalcaratus_Double-spurred Spurfowl
+Pternistis capensis_Cape Spurfowl
+Pternistis erckelii_Erckel's Spurfowl
+Pternistis hildebrandti_Hildebrandt's Spurfowl
+Pternistis leucoscepus_Yellow-necked Spurfowl
+Pternistis natalensis_Natal Spurfowl
+Pternistis squamatus_Scaly Spurfowl
+Pternistis swainsonii_Swainson's Spurfowl
+Pterocles alchata_Pin-tailed Sandgrouse
+Pterocles exustus_Chestnut-bellied Sandgrouse
+Pterocles namaqua_Namaqua Sandgrouse
+Pterocles orientalis_Black-bellied Sandgrouse
+Pterocles senegallus_Spotted Sandgrouse
+Pterodroma cervicalis_White-necked Petrel
+Pterodroma cookii_Cook's Petrel
+Pterodroma externa_Juan Fernandez Petrel
+Pterodroma hypoleuca_Bonin Petrel
+Pterodroma inexpectata_Mottled Petrel
+Pterodroma madeira_Zino's Petrel
+Pterodroma neglecta_Kermadec Petrel
+Pterodroma nigripennis_Black-winged Petrel
+Pterodroma phaeopygia_Galapagos Petrel
+Pterodroma sandwichensis_Hawaiian Petrel
+Pteroglossus aracari_Black-necked Aracari
+Pteroglossus azara_Ivory-billed Aracari
+Pteroglossus bailloni_Saffron Toucanet
+Pteroglossus beauharnaisii_Curl-crested Aracari
+Pteroglossus bitorquatus_Red-necked Aracari
+Pteroglossus castanotis_Chestnut-eared Aracari
+Pteroglossus frantzii_Fiery-billed Aracari
+Pteroglossus inscriptus_Lettered Aracari
+Pteroglossus pluricinctus_Many-banded Aracari
+Pteroglossus torquatus_Collared Aracari
+Pterophylla camellifolia_Common True Katydid
+Pteroptochos castaneus_Chestnut-throated Huet-huet
+Pteroptochos megapodius_Moustached Turca
+Pteroptochos tarnii_Black-throated Huet-huet
+Pterorhinus albogularis_White-throated Laughingthrush
+Pterorhinus berthemyi_Buffy Laughingthrush
+Pterorhinus chinensis_Black-throated Laughingthrush
+Pterorhinus davidi_Pere David's Laughingthrush
+Pterorhinus delesserti_Wayanad Laughingthrush
+Pterorhinus mitratus_Chestnut-capped Laughingthrush
+Pterorhinus pectoralis_Greater Necklaced Laughingthrush
+Pterorhinus perspicillatus_Masked Laughingthrush
+Pterorhinus poecilorhynchus_Rusty Laughingthrush
+Pterorhinus ruficollis_Rufous-necked Laughingthrush
+Pterorhinus sannio_White-browed Laughingthrush
+Pterorhinus treacheri_Chestnut-hooded Laughingthrush
+Pteruthius aeralatus_White-browed Shrike-Babbler
+Pteruthius intermedius_Clicking Shrike-Babbler
+Pteruthius melanotis_Black-eared Shrike-Babbler
+Pteruthius ripleyi_Himalayan Shrike-Babbler
+Pteruthius rufiventer_Black-headed Shrike-Babbler
+Pteruthius xanthochlorus_Green Shrike-Babbler
+Ptilinopus iozonus_Orange-bellied Fruit-Dove
+Ptilinopus magnificus_Wompoo Fruit-Dove
+Ptilinopus melanospilus_Black-naped Fruit-Dove
+Ptilinopus occipitalis_Yellow-breasted Fruit-Dove
+Ptilinopus pelewensis_Palau Fruit-Dove
+Ptilinopus porphyraceus_Crimson-crowned Fruit-Dove
+Ptilinopus regina_Rose-crowned Fruit-Dove
+Ptilinopus rivoli_White-breasted Fruit-Dove
+Ptilinopus solomonensis_Yellow-bibbed Fruit-Dove
+Ptilinopus superbus_Superb Fruit-Dove
+Ptilinopus viridis_Claret-breasted Fruit-Dove
+Ptiliogonys caudatus_Long-tailed Silky-flycatcher
+Ptiliogonys cinereus_Grey Silky-flycatcher
+Ptilocichla falcata_Falcated Wren-Babbler
+Ptilocichla leucogrammica_Bornean Wren-Babbler
+Ptilocichla mindanensis_Striated Wren-Babbler
+Ptilonorhynchus violaceus_Satin Bowerbird
+Ptilopachus petrosus_Stone Partridge
+Ptiloprora guisei_Rufous-backed Honeyeater
+Ptiloprora perstriata_Grey-streaked Honeyeater
+Ptilopsis leucotis_Northern White-faced Owl
+Ptiloris magnificus_Magnificent Riflebird
+Ptiloris paradiseus_Paradise Riflebird
+Ptiloris victoriae_Victoria's Riflebird
+Ptilorrhoa caerulescens_Blue Jewel-babbler
+Ptilorrhoa castanonota_Chestnut-backed Jewel-babbler
+Ptilorrhoa leucosticta_Spotted Jewel-babbler
+Ptilostomus afer_Piapiac
+Ptilotula fusca_Fuscous Honeyeater
+Ptilotula ornata_Yellow-plumed Honeyeater
+Ptilotula penicillata_White-plumed Honeyeater
+Ptiloxena atroviolacea_Cuban Blackbird
+Ptyonoprogne concolor_Dusky Crag Martin
+Ptyonoprogne fuligula_Rock Martin
+Ptyonoprogne rupestris_Eurasian Crag Martin
+Pucrasia macrolopha_Koklass Pheasant
+Puffinus bailloni_Tropical Shearwater
+Puffinus nativitatis_Christmas Shearwater
+Puffinus newelli_Newell's Shearwater
+Puffinus puffinus_Manx Shearwater
+Pulsatrix koeniswaldiana_Tawny-browed Owl
+Pulsatrix melanota_Band-bellied Owl
+Pulsatrix perspicillata_Spectacled Owl
+Purnella albifrons_White-fronted Honeyeater
+Purpureicephalus spurius_Red-capped Parrot
+Pycnonotus aurigaster_Sooty-headed Bulbul
+Pycnonotus barbatus_Common Bulbul
+Pycnonotus brunneus_Red-eyed Bulbul
+Pycnonotus cafer_Red-vented Bulbul
+Pycnonotus capensis_Cape Bulbul
+Pycnonotus conradi_Streak-eared Bulbul
+Pycnonotus finlaysoni_Stripe-throated Bulbul
+Pycnonotus flavescens_Flavescent Bulbul
+Pycnonotus goiavier_Yellow-vented Bulbul
+Pycnonotus jocosus_Red-whiskered Bulbul
+Pycnonotus leucogenys_Himalayan Bulbul
+Pycnonotus leucotis_White-eared Bulbul
+Pycnonotus luteolus_White-browed Bulbul
+Pycnonotus nigricans_Black-fronted Bulbul
+Pycnonotus plumosus_Olive-winged Bulbul
+Pycnonotus simplex_Cream-vented Bulbul
+Pycnonotus sinensis_Light-vented Bulbul
+Pycnonotus striatus_Striated Bulbul
+Pycnonotus taivanus_Styan's Bulbul
+Pycnonotus xantholaemus_Yellow-throated Bulbul
+Pycnonotus xanthopygos_White-spectacled Bulbul
+Pycnonotus xanthorrhous_Brown-breasted Bulbul
+Pycnonotus zeylanicus_Straw-headed Bulbul
+Pycnoptilus floccosus_Pilotbird
+Pygarrhichas albogularis_White-throated Treerunner
+Pygiptila stellaris_Spot-winged Antshrike
+Pygochelidon cyanoleuca_Blue-and-white Swallow
+Pygoscelis adeliae_Adelie Penguin
+Pygoscelis antarcticus_Chinstrap Penguin
+Pygoscelis papua_Gentoo Penguin
+Pyriglena atra_Fringe-backed Fire-eye
+Pyriglena leuconota_East Amazonian Fire-eye
+Pyriglena leucoptera_White-shouldered Fire-eye
+Pyriglena maura_Western Fire-eye
+Pyrilia barrabandi_Orange-cheeked Parrot
+Pyrilia caica_Caica Parrot
+Pyrilia haematotis_Brown-hooded Parrot
+Pyrilia pulchra_Rose-faced Parrot
+Pyrilia pyrilia_Saffron-headed Parrot
+Pyrocephalus rubinus_Vermilion Flycatcher
+Pyroderus scutatus_Red-ruffed Fruitcrow
+Pyrope pyrope_Fire-eyed Diucon
+Pyrrhocorax graculus_Alpine Chough
+Pyrrhocorax pyrrhocorax_Red-billed Chough
+Pyrrholaemus brunneus_Redthroat
+Pyrrholaemus sagittatus_Speckled Warbler
+Pyrrhomyias cinnamomeus_Cinnamon Flycatcher
+Pyrrhula erythaca_Grey-headed Bullfinch
+Pyrrhula nipalensis_Brown Bullfinch
+Pyrrhula pyrrhula_Eurasian Bullfinch
+Pyrrhura albipectus_White-necked Parakeet
+Pyrrhura amazonum_Santarem Parakeet
+Pyrrhura calliptera_Brown-breasted Parakeet
+Pyrrhura cruentata_Ochre-marked Parakeet
+Pyrrhura frontalis_Maroon-bellied Parakeet
+Pyrrhura hoematotis_Red-eared Parakeet
+Pyrrhura hoffmanni_Sulphur-winged Parakeet
+Pyrrhura leucotis_Maroon-faced Parakeet
+Pyrrhura melanura_Maroon-tailed Parakeet
+Pyrrhura molinae_Green-cheeked Parakeet
+Pyrrhura orcesi_El Oro Parakeet
+Pyrrhura perlata_Crimson-bellied Parakeet
+Pyrrhura picta_Painted Parakeet
+Pyrrhura rhodocephala_Rose-headed Parakeet
+Pyrrhura roseifrons_Rose-fronted Parakeet
+Pyrrhura rupicola_Black-capped Parakeet
+Pyrrhura viridicata_Santa Marta Parakeet
+Pytilia melba_Green-winged Pytilia
+Quelea quelea_Red-billed Quelea
+Querula purpurata_Purple-throated Fruitcrow
+Quiscalus lugubris_Carib Grackle
+Quiscalus major_Boat-tailed Grackle
+Quiscalus mexicanus_Great-tailed Grackle
+Quiscalus nicaraguensis_Nicaraguan Grackle
+Quiscalus niger_Greater Antillean Grackle
+Quiscalus quiscula_Common Grackle
+Radjah radjah_Radjah Shelduck
+Rallina eurizonoides_Slaty-legged Crake
+Rallina fasciata_Red-legged Crake
+Rallina tricolor_Red-necked Crake
+Rallus antarcticus_Austral Rail
+Rallus aquaticus_Water Rail
+Rallus caerulescens_African Rail
+Rallus crepitans_Clapper Rail
+Rallus elegans_King Rail
+Rallus indicus_Brown-cheeked Rail
+Rallus limicola_Virginia Rail
+Rallus longirostris_Mangrove Rail
+Rallus obsoletus_Ridgway's Rail
+Rallus semiplumbeus_Bogota Rail
+Rallus tenuirostris_Aztec Rail
+Ramphastos ambiguus_Yellow-throated Toucan
+Ramphastos brevis_Choco Toucan
+Ramphastos dicolorus_Red-breasted Toucan
+Ramphastos sulfuratus_Keel-billed Toucan
+Ramphastos toco_Toco Toucan
+Ramphastos tucanus_White-throated Toucan
+Ramphastos vitellinus_Channel-billed Toucan
+Ramphocaenus melanurus_Long-billed Gnatwren
+Ramphocaenus sticturus_Chattering Gnatwren
+Ramphocelus bresilius_Brazilian Tanager
+Ramphocelus carbo_Silver-beaked Tanager
+Ramphocelus dimidiatus_Crimson-backed Tanager
+Ramphocelus flammigerus_Flame-rumped Tanager
+Ramphocelus melanogaster_Black-bellied Tanager
+Ramphocelus nigrogularis_Masked Crimson Tanager
+Ramphocelus passerinii_Scarlet-rumped Tanager
+Ramphocelus sanguinolentus_Crimson-collared Tanager
+Ramphodon naevius_Saw-billed Hermit
+Ramphomicron microrhynchum_Purple-backed Thornbill
+Ramphotrigon flammulatum_Flammulated Flycatcher
+Ramphotrigon fuscicauda_Dusky-tailed Flatbill
+Ramphotrigon megacephalum_Large-headed Flatbill
+Ramphotrigon ruficauda_Rufous-tailed Flatbill
+Ramsayornis modestus_Brown-backed Honeyeater
+Rauenia bonariensis_Blue-and-yellow Tanager
+Recurvirostra americana_American Avocet
+Recurvirostra andina_Andean Avocet
+Recurvirostra avosetta_Pied Avocet
+Regulus goodfellowi_Flamecrest
+Regulus ignicapilla_Common Firecrest
+Regulus madeirensis_Madeira Firecrest
+Regulus regulus_Goldcrest
+Regulus satrapa_Golden-crowned Kinglet
+Reinwardtipicus validus_Orange-backed Woodpecker
+Reinwardtoena reinwardti_Great Cuckoo-Dove
+Remiz consobrinus_Chinese Penduline Tit
+Remiz coronatus_White-crowned Penduline Tit
+Remiz pendulinus_Eurasian Penduline Tit
+Rhabdotorrhinus corrugatus_Wrinkled Hornbill
+Rhabdotorrhinus exarhatus_Sulawesi Hornbill
+Rhaphidura leucopygialis_Silver-rumped Spinetail
+Rhea americana_Greater Rhea
+Rhegmatorhina cristata_Chestnut-crested Antbird
+Rhegmatorhina gymnops_Bare-eyed Antbird
+Rhegmatorhina hoffmannsi_White-breasted Antbird
+Rhegmatorhina melanosticta_Hairy-crested Antbird
+Rhinocrypta lanceolata_Crested Gallito
+Rhinopomastus cyanomelas_Common Scimitarbill
+Rhinortha chlorophaea_Raffles's Malkoha
+Rhipidura albicollis_White-throated Fantail
+Rhipidura albiscapa_Grey Fantail
+Rhipidura albogularis_Spot-breasted Fantail
+Rhipidura albolimbata_Friendly Fantail
+Rhipidura atra_Black Fantail
+Rhipidura aureola_White-browed Fantail
+Rhipidura brachyrhyncha_Dimorphic Fantail
+Rhipidura cyaniceps_Blue-headed Fantail
+Rhipidura dryas_Arafura Fantail
+Rhipidura fuliginosa_New Zealand Fantail
+Rhipidura javanica_Malaysian Pied-Fantail
+Rhipidura leucophrys_Willie-wagtail
+Rhipidura leucothorax_White-bellied Thicket-Fantail
+Rhipidura maculipectus_Black Thicket-Fantail
+Rhipidura nigritorquis_Philippine Pied-Fantail
+Rhipidura perlata_Spotted Fantail
+Rhipidura rufifrons_Australian Rufous Fantail
+Rhipidura rufiventris_Northern Fantail
+Rhipidura teysmanni_Sulawesi Fantail
+Rhipidura threnothorax_Sooty Thicket-Fantail
+Rhipidura verreauxi_New Caledonian Streaked Fantail
+Rhodinocichla rosea_Rosy Thrush-Tanager
+Rhodophoneus cruentus_Rosy-patched Bushshrike
+Rhodospingus cruentus_Crimson-breasted Finch
+Rhodospiza obsoleta_Desert Finch
+Rhodostethia rosea_Ross's Gull
+Rhodothraupis celaeno_Crimson-collared Grosbeak
+Rhopias gularis_Star-throated Antwren
+Rhopophilus pekinensis_Beijing Babbler
+Rhopornis ardesiacus_Slender Antbird
+Rhopospina alaudina_Band-tailed Sierra Finch
+Rhopospina caerulescens_Blue Finch
+Rhopospina fruticeti_Mourning Sierra Finch
+Rhynchocyclus brevirostris_Eye-ringed Flatbill
+Rhynchocyclus olivaceus_Eastern Olivaceous Flatbill
+Rhynchophanes mccownii_Thick-billed Longspur
+Rhynchopsitta pachyrhyncha_Thick-billed Parrot
+Rhynchopsitta terrisi_Maroon-fronted Parrot
+Rhynchortyx cinctus_Tawny-faced Quail
+Rhynchospiza stolzmanni_Tumbes Sparrow
+Rhynchospiza strigiceps_Chaco Sparrow
+Rhynchotus rufescens_Red-winged Tinamou
+Rhynochetos jubatus_Kagu
+Rhyticeros cassidix_Knobbed Hornbill
+Rhyticeros plicatus_Blyth's Hornbill
+Rhyticeros undulatus_Wreathed Hornbill
+Rhytipterna holerythra_Rufous Mourner
+Rhytipterna immunda_Pale-bellied Mourner
+Rhytipterna simplex_Greyish Mourner
+Riparia chinensis_Grey-throated Martin
+Riparia diluta_Pale Martin
+Riparia paludicola_Plain Martin
+Riparia riparia_Sand Martin
+Rissa tridactyla_Black-legged Kittiwake
+Rollulus rouloul_Crested Partridge
+Roraimia adusta_Roraiman Barbtail
+Rostratula benghalensis_Greater Painted-Snipe
+Rostrhamus sociabilis_Snail Kite
+Rubigula erythropthalmos_Spectacled Bulbul
+Rubigula flaviventris_Black-crested Bulbul
+Rubigula gularis_Flame-throated Bulbul
+Rupicola peruvianus_Andean Cock-of-the-rock
+Rupicola rupicola_Guianan Cock-of-the-rock
+Rupornis magnirostris_Roadside Hawk
+Rynchops niger_Black Skimmer
+Sakesphorus canadensis_Black-crested Antshrike
+Sakesphorus cristatus_Silvery-cheeked Antshrike
+Sakesphorus luctuosus_Glossy Antshrike
+Salpinctes obsoletus_Rock Wren
+Salpornis salvadori_African Spotted Creeper
+Saltator albicollis_Lesser Antillean Saltator
+Saltator atriceps_Black-headed Saltator
+Saltator atripennis_Black-winged Saltator
+Saltator aurantiirostris_Golden-billed Saltator
+Saltator cinctus_Masked Saltator
+Saltator coerulescens_Bluish-grey Saltator
+Saltator fuliginosus_Black-throated Grosbeak
+Saltator grandis_Cinnamon-bellied Saltator
+Saltator grossus_Slate-coloured Grosbeak
+Saltator maxillosus_Thick-billed Saltator
+Saltator maximus_Buff-throated Saltator
+Saltator nigriceps_Black-cowled Saltator
+Saltator olivascens_Olive-grey Saltator
+Saltator orenocensis_Orinocan Saltator
+Saltator similis_Green-winged Saltator
+Saltator striatipectus_Streaked Saltator
+Saltatricula atricollis_Black-throated Saltator
+Saltatricula multicolor_Many-coloured Chaco Finch
+Sapayoa aenigma_Sapayoa
+Sappho sparganurus_Red-tailed Comet
+Sarcops calvus_Coleto
+Sarothrura elegans_Buff-spotted Flufftail
+Sarothrura insularis_Madagascar Flufftail
+Sarothrura pulchra_White-spotted Flufftail
+Sarothrura rufa_Red-chested Flufftail
+Sasia abnormis_Rufous Piculet
+Sasia ochracea_White-browed Piculet
+Saucerottia beryllina_Berylline Hummingbird
+Saucerottia cyanocephala_Azure-crowned Hummingbird
+Saucerottia tobaci_Copper-rumped Hummingbird
+Saundersilarus saundersi_Saunders's Gull
+Saxicola caprata_Pied Bushchat
+Saxicola ferreus_Grey Bushchat
+Saxicola maurus_Siberian Stonechat
+Saxicola rubetra_Whinchat
+Saxicola rubicola_European Stonechat
+Saxicola stejnegeri_Amur Stonechat
+Saxicola torquatus_African Stonechat
+Sayornis nigricans_Black Phoebe
+Sayornis phoebe_Eastern Phoebe
+Sayornis saya_Say's Phoebe
+Scaphiopus couchii_Couch's Spadefoot
+Scelorchilus albicollis_White-throated Tapaculo
+Scelorchilus rubecula_Chucao Tapaculo
+Scenopoeetes dentirostris_Tooth-billed Bowerbird
+Schetba rufa_Rufous Vanga
+Schiffornis aenea_Foothill Schiffornis
+Schiffornis major_Varzea Schiffornis
+Schiffornis olivacea_Olivaceous Schiffornis
+Schiffornis stenorhyncha_Russet-winged Schiffornis
+Schiffornis turdina_Brown-winged Schiffornis
+Schiffornis veraepacis_Northern Schiffornis
+Schiffornis virescens_Greenish Schiffornis
+Schistes geoffroyi_Geoffroy's Daggerbill
+Schistochlamys melanopis_Black-faced Tanager
+Schistochlamys ruficapillus_Cinnamon Tanager
+Schoenicola platyurus_Broad-tailed Grassbird
+Schoenicola striatus_Bristled Grassbird
+Schoeniophylax phryganophilus_Chotoy Spinetail
+Schoeniparus brunneus_Dusky Fulvetta
+Schoeniparus castaneceps_Rufous-winged Fulvetta
+Schoeniparus cinereus_Yellow-throated Fulvetta
+Schoeniparus dubius_Rusty-capped Fulvetta
+Schoeniparus rufogularis_Rufous-throated Fulvetta
+Sciaphylax castanea_Zimmer's Antbird
+Sciaphylax hemimelaena_Chestnut-tailed Antbird
+Sciurus carolinensis_Eastern Gray Squirrel
+Sclateria naevia_Silvered Antbird
+Scleroptila afra_Grey-winged Francolin
+Scleroptila gutturalis_Orange River Francolin
+Scleroptila levaillantii_Red-winged Francolin
+Scleroptila shelleyi_Shelley's Francolin
+Sclerurus albigularis_Grey-throated Leaftosser
+Sclerurus caudacutus_Black-tailed Leaftosser
+Sclerurus guatemalensis_Scaly-throated Leaftosser
+Sclerurus mexicanus_Middle American Leaftosser
+Sclerurus obscurior_South American Leaftosser
+Sclerurus rufigularis_Short-billed Leaftosser
+Sclerurus scansor_Rufous-breasted Leaftosser
+Scolopax bukidnonensis_Bukidnon Woodcock
+Scolopax minor_American Woodcock
+Scolopax rusticola_Eurasian Woodcock
+Scopus umbretta_Hamerkop
+Scotocerca inquieta_Scrub Warbler
+Scudderia curvicauda_Curve-tailed Bush Katydid
+Scudderia furcata_Fork-tailed Bush Katydid
+Scudderia texensis_Texas Bush Katydid
+Scytalopus acutirostris_Tschudi's Tapaculo
+Scytalopus affinis_Ancash Tapaculo
+Scytalopus altirostris_Neblina Tapaculo
+Scytalopus alvarezlopezi_Tatama Tapaculo
+Scytalopus androstictus_Loja Tapaculo
+Scytalopus argentifrons_Silvery-fronted Tapaculo
+Scytalopus atratus_White-crowned Tapaculo
+Scytalopus bolivianus_Bolivian Tapaculo
+Scytalopus canus_Paramillo Tapaculo
+Scytalopus caracae_Caracas Tapaculo
+Scytalopus chocoensis_Choco Tapaculo
+Scytalopus diamantinensis_Diamantina Tapaculo
+Scytalopus femoralis_Rufous-vented Tapaculo
+Scytalopus frankeae_Jalca Tapaculo
+Scytalopus fuscus_Dusky Tapaculo
+Scytalopus griseicollis_Pale-bellied Tapaculo
+Scytalopus intermedius_Utcubamba Tapaculo
+Scytalopus iraiensis_Marsh Tapaculo
+Scytalopus latebricola_Brown-rumped Tapaculo
+Scytalopus latrans_Blackish Tapaculo
+Scytalopus macropus_Large-footed Tapaculo
+Scytalopus magellanicus_Magellanic Tapaculo
+Scytalopus meridanus_Merida Tapaculo
+Scytalopus micropterus_Long-tailed Tapaculo
+Scytalopus novacapitalis_Brasilia Tapaculo
+Scytalopus opacus_Paramo Tapaculo
+Scytalopus pachecoi_Planalto Tapaculo
+Scytalopus parkeri_Chusquea Tapaculo
+Scytalopus parvirostris_Trilling Tapaculo
+Scytalopus perijanus_Perija Tapaculo
+Scytalopus petrophilus_Rock Tapaculo
+Scytalopus robbinsi_Ecuadorian Tapaculo
+Scytalopus rodriguezi_Magdalena Tapaculo
+Scytalopus sanctaemartae_Santa Marta Tapaculo
+Scytalopus schulenbergi_Diademed Tapaculo
+Scytalopus simonsi_Puna Tapaculo
+Scytalopus speluncae_Mouse-coloured Tapaculo
+Scytalopus spillmanni_Spillmann's Tapaculo
+Scytalopus stilesi_Stiles's Tapaculo
+Scytalopus superciliaris_White-browed Tapaculo
+Scytalopus unicolor_Unicoloured Tapaculo
+Scytalopus urubambae_Vilcabamba Tapaculo
+Scytalopus vicinior_Nariño Tapaculo
+Scytalopus zimmeri_Zimmer's Tapaculo
+Scythrops novaehollandiae_Channel-billed Cuckoo
+Seiurus aurocapilla_Ovenbird
+Selasphorus calliope_Calliope Hummingbird
+Selasphorus ellioti_Wine-throated Hummingbird
+Selasphorus heloisa_Bumblebee Hummingbird
+Selasphorus platycercus_Broad-tailed Hummingbird
+Selasphorus rufus_Rufous Hummingbird
+Selasphorus sasin_Allen's Hummingbird
+Selenidera gouldii_Gould's Toucanet
+Selenidera maculirostris_Spot-billed Toucanet
+Selenidera piperivora_Guianan Toucanet
+Selenidera reinwardtii_Golden-collared Toucanet
+Selenidera spectabilis_Yellow-eared Toucanet
+Seleucidis melanoleucus_Twelve-wired Bird-of-Paradise
+Semioptera wallacii_Standardwing Bird-of-Paradise
+Semnornis frantzii_Prong-billed Barbet
+Semnornis ramphastinus_Toucan Barbet
+Sephanoides sephaniodes_Green-backed Firecrown
+Sericornis citreogularis_Yellow-throated Scrubwren
+Sericornis frontalis_White-browed Scrubwren
+Sericornis humilis_Tasmanian Scrubwren
+Sericornis magnirostra_Large-billed Scrubwren
+Sericornis papuensis_Papuan Scrubwren
+Sericossypha albocristata_White-capped Tanager
+Serilophus lunatus_Silver-breasted Broadbill
+Serinus alario_Black-headed Canary
+Serinus canaria_Atlantic Canary
+Serinus canicollis_Cape Canary
+Serinus flavivertex_Yellow-crowned Canary
+Serinus pusillus_Red-fronted Serin
+Serinus serinus_European Serin
+Serpophaga cinerea_Torrent Tyrannulet
+Serpophaga griseicapilla_Straneck's Tyrannulet
+Serpophaga hypoleuca_River Tyrannulet
+Serpophaga munda_White-bellied Tyrannulet
+Serpophaga nigricans_Sooty Tyrannulet
+Serpophaga subcristata_White-crested Tyrannulet
+Setopagis parvula_Little Nightjar
+Setophaga adelaidae_Adelaide's Warbler
+Setophaga americana_Northern Parula
+Setophaga caerulescens_Black-throated Blue Warbler
+Setophaga castanea_Bay-breasted Warbler
+Setophaga cerulea_Cerulean Warbler
+Setophaga chrysoparia_Golden-cheeked Warbler
+Setophaga citrina_Hooded Warbler
+Setophaga coronata_Yellow-rumped Warbler
+Setophaga discolor_Prairie Warbler
+Setophaga dominica_Yellow-throated Warbler
+Setophaga fusca_Blackburnian Warbler
+Setophaga graciae_Grace's Warbler
+Setophaga kirtlandii_Kirtland's Warbler
+Setophaga magnolia_Magnolia Warbler
+Setophaga nigrescens_Black-throated Grey Warbler
+Setophaga occidentalis_Hermit Warbler
+Setophaga palmarum_Palm Warbler
+Setophaga pensylvanica_Chestnut-sided Warbler
+Setophaga petechia_Yellow Warbler
+Setophaga pinus_Pine Warbler
+Setophaga pitiayumi_Tropical Parula
+Setophaga pityophila_Olive-capped Warbler
+Setophaga ruticilla_American Redstart
+Setophaga striata_Blackpoll Warbler
+Setophaga tigrina_Cape May Warbler
+Setophaga townsendi_Townsend's Warbler
+Setophaga virens_Black-throated Green Warbler
+Sheppardia gunningi_East Coast Akalat
+Sheppardia sharpei_Sharpe's Akalat
+Sholicola albiventris_White-bellied Sholakili
+Sholicola major_Nilgiri Sholakili
+Sialia currucoides_Mountain Bluebird
+Sialia mexicana_Western Bluebird
+Sialia sialis_Eastern Bluebird
+Sicalis auriventris_Greater Yellow-Finch
+Sicalis citrina_Stripe-tailed Yellow-Finch
+Sicalis flaveola_Saffron Finch
+Sicalis lebruni_Patagonian Yellow-Finch
+Sicalis luteocephala_Citron-headed Yellow-Finch
+Sicalis luteola_Grassland Yellow-Finch
+Sicalis olivascens_Greenish Yellow-Finch
+Sicalis uropygialis_Bright-rumped Yellow-Finch
+Sinosuthora webbiana_Vinous-throated Parrotbill
+Siphonorhis brewsteri_Least Pauraque
+Sipia berlepschi_Stub-tailed Antbird
+Sipia laemosticta_Dull-mantled Antbird
+Sipia nigricauda_Esmeraldas Antbird
+Sipia palliata_Magdalena Antbird
+Siren_Siren
+Sirystes albocinereus_White-rumped Sirystes
+Sirystes albogriseus_Choco Sirystes
+Sirystes sibilator_Sibilant Sirystes
+Sitta canadensis_Red-breasted Nuthatch
+Sitta carolinensis_White-breasted Nuthatch
+Sitta cinnamoventris_Chestnut-bellied Nuthatch
+Sitta europaea_Eurasian Nuthatch
+Sitta frontalis_Velvet-fronted Nuthatch
+Sitta himalayensis_White-tailed Nuthatch
+Sitta krueperi_Krüper's Nuthatch
+Sitta magna_Giant Nuthatch
+Sitta nagaensis_Chestnut-vented Nuthatch
+Sitta neumayer_Western Rock Nuthatch
+Sitta pusilla_Brown-headed Nuthatch
+Sitta pygmaea_Pygmy Nuthatch
+Sitta tephronota_Eastern Rock Nuthatch
+Sitta villosa_Snowy-browed Nuthatch
+Sitta whiteheadi_Corsican Nuthatch
+Sitta yunnanensis_Yunnan Nuthatch
+Sittasomus griseicapillus_Olivaceous Woodcreeper
+Sittiparus castaneoventris_Chestnut-bellied Tit
+Sittiparus owstoni_Owston's Tit
+Sittiparus varius_Varied Tit
+Smicrornis brevirostris_Weebill
+Smithornis capensis_African Broadbill
+Smithornis rufolateralis_Rufous-sided Broadbill
+Snowornis subalaris_Grey-tailed Piha
+Somateria mollissima_Common Eider
+Somateria spectabilis_King Eider
+Spartonoica maluroides_Bay-capped Wren-Spinetail
+Spatula clypeata_Northern Shoveler
+Spatula cyanoptera_Cinnamon Teal
+Spatula discors_Blue-winged Teal
+Spatula platalea_Red Shoveler
+Spatula puna_Puna Teal
+Spatula querquedula_Garganey
+Spea bombifrons_Plains Spadefoot
+Spelaeornis caudatus_Rufous-throated Wren-Babbler
+Spelaeornis oatesi_Chin Hills Wren-Babbler
+Spelaeornis troglodytoides_Bar-winged Wren-Babbler
+Spermestes cucullata_Bronze Mannikin
+Spermophaga haematina_Western Bluebill
+Sphecotheres vieilloti_Australasian Figbird
+Spheniscus demersus_African Penguin
+Spheniscus magellanicus_Magellanic Penguin
+Sphenoeacus afer_Cape Grassbird
+Sphenopsis frontalis_Oleaginous Hemispingus
+Sphenopsis melanotis_Black-eared Hemispingus
+Sphyrapicus nuchalis_Red-naped Sapsucker
+Sphyrapicus ruber_Red-breasted Sapsucker
+Sphyrapicus thyroideus_Williamson's Sapsucker
+Sphyrapicus varius_Yellow-bellied Sapsucker
+Spiloptila clamans_Cricket Longtail
+Spilornis cheela_Crested Serpent-Eagle
+Spilornis holospilus_Philippine Serpent-Eagle
+Spindalis zena_Western Spindalis
+Spinus atratus_Black Siskin
+Spinus barbatus_Black-chinned Siskin
+Spinus crassirostris_Thick-billed Siskin
+Spinus cucullatus_Red Siskin
+Spinus lawrencei_Lawrence's Goldfinch
+Spinus magellanicus_Hooded Siskin
+Spinus notatus_Black-headed Siskin
+Spinus olivaceus_Olivaceous Siskin
+Spinus pinus_Pine Siskin
+Spinus psaltria_Lesser Goldfinch
+Spinus spinescens_Andean Siskin
+Spinus spinus_Eurasian Siskin
+Spinus tristis_American Goldfinch
+Spinus xanthogastrus_Yellow-bellied Siskin
+Spiza americana_Dickcissel
+Spizaetus isidori_Black-and-chestnut Eagle
+Spizaetus melanoleucus_Black-and-white Hawk-Eagle
+Spizaetus ornatus_Ornate Hawk-Eagle
+Spizaetus tyrannus_Black Hawk-Eagle
+Spizella atrogularis_Black-chinned Sparrow
+Spizella breweri_Brewer's Sparrow
+Spizella pallida_Clay-coloured Sparrow
+Spizella passerina_Chipping Sparrow
+Spizella pusilla_Field Sparrow
+Spizella wortheni_Worthen's Sparrow
+Spizelloides arborea_American Tree Sparrow
+Spiziapteryx circumcincta_Spot-winged Falconet
+Spizixos canifrons_Crested Finchbill
+Spizixos semitorques_Collared Finchbill
+Spodiopsar cineraceus_White-cheeked Starling
+Spodiopsar sericeus_Red-billed Starling
+Spodiornis rusticus_Slaty Finch
+Sporathraupis cyanocephala_Blue-capped Tanager
+Sporophila albogularis_White-throated Seedeater
+Sporophila angolensis_Chestnut-bellied Seed-Finch
+Sporophila atrirostris_Black-billed Seed-Finch
+Sporophila bouvreuil_Copper Seedeater
+Sporophila bouvronides_Lesson's Seedeater
+Sporophila caerulescens_Double-collared Seedeater
+Sporophila castaneiventris_Chestnut-bellied Seedeater
+Sporophila cinnamomea_Chestnut Seedeater
+Sporophila collaris_Rusty-collared Seedeater
+Sporophila corvina_Variable Seedeater
+Sporophila crassirostris_Large-billed Seed-Finch
+Sporophila falcirostris_Temminck's Seedeater
+Sporophila fringilloides_White-naped Seedeater
+Sporophila frontalis_Buffy-fronted Seedeater
+Sporophila funerea_Thick-billed Seed-Finch
+Sporophila hypochroma_Rufous-rumped Seedeater
+Sporophila hypoxantha_Tawny-bellied Seedeater
+Sporophila intermedia_Grey Seedeater
+Sporophila leucoptera_White-bellied Seedeater
+Sporophila lineola_Lined Seedeater
+Sporophila luctuosa_Black-and-white Seedeater
+Sporophila minuta_Ruddy-breasted Seedeater
+Sporophila morelleti_Morelet's Seedeater
+Sporophila murallae_Caqueta Seedeater
+Sporophila nigricollis_Yellow-bellied Seedeater
+Sporophila nuttingi_Nicaraguan Seed-Finch
+Sporophila palustris_Marsh Seedeater
+Sporophila peruviana_Parrot-billed Seedeater
+Sporophila pileata_Pearly-bellied Seedeater
+Sporophila plumbea_Plumbeous Seedeater
+Sporophila ruficollis_Dark-throated Seedeater
+Sporophila schistacea_Slate-coloured Seedeater
+Sporophila simplex_Drab Seedeater
+Sporophila telasco_Chestnut-throated Seedeater
+Sporophila torqueola_Cinnamon-rumped Seedeater
+Sporopipes frontalis_Speckle-fronted Weaver
+Sporopipes squamifrons_Scaly Weaver
+Stachyris maculata_Chestnut-rumped Babbler
+Stachyris nigriceps_Grey-throated Babbler
+Stachyris nigricollis_Black-throated Babbler
+Stachyris poliocephala_Grey-headed Babbler
+Stachyris strialata_Spot-necked Babbler
+Stachyris thoracica_White-bibbed Babbler
+Stactolaema leucotis_White-eared Barbet
+Stactolaema olivacea_Green Barbet
+Stagonopleura bella_Beautiful Firetail
+Staphida torqueola_Indochinese Yuhina
+Steatornis caripensis_Oilbird
+Stelgidillas gracilirostris_Slender-billed Greenbul
+Stelgidopteryx ruficollis_Southern Rough-winged Swallow
+Stelgidopteryx serripennis_Northern Rough-winged Swallow
+Stenostira scita_Fairy Flycatcher
+Stephanoaetus coronatus_Crowned Eagle
+Stephanophorus diadematus_Diademed Tanager
+Stephanoxis lalandi_Green-crowned Plovercrest
+Stephanoxis loddigesii_Purple-crowned Plovercrest
+Stercorarius antarcticus_Brown Skua
+Stercorarius longicaudus_Long-tailed Skua
+Stercorarius maccormicki_South Polar Skua
+Stercorarius parasiticus_Arctic Skua
+Stercorarius pomarinus_Pomarine Skua
+Stercorarius skua_Great Skua
+Sterna aurantia_River Tern
+Sterna dougallii_Roseate Tern
+Sterna forsteri_Forster's Tern
+Sterna hirundinacea_South American Tern
+Sterna hirundo_Common Tern
+Sterna paradisaea_Arctic Tern
+Sterna repressa_White-cheeked Tern
+Sterna striata_White-fronted Tern
+Sterna sumatrana_Black-naped Tern
+Sterna trudeaui_Snowy-crowned Tern
+Sterna vittata_Antarctic Tern
+Sternula albifrons_Little Tern
+Sternula antillarum_Least Tern
+Sternula saundersi_Saunders's Tern
+Sternula superciliaris_Yellow-billed Tern
+Stigmatura budytoides_Greater Wagtail-Tyrant
+Stigmatura napensis_Lesser Wagtail-Tyrant
+Stilpnia cayana_Burnished-buff Tanager
+Stilpnia cyanicollis_Blue-necked Tanager
+Stilpnia cyanoptera_Black-headed Tanager
+Stilpnia heinei_Black-capped Tanager
+Stilpnia larvata_Golden-hooded Tanager
+Stilpnia nigrocincta_Masked Tanager
+Stilpnia peruviana_Black-backed Tanager
+Stilpnia preciosa_Chestnut-backed Tanager
+Stilpnia vitriolina_Scrub Tanager
+Stiphrornis erythrothorax_Orange-breasted Forest Robin
+Stipiturus malachurus_Southern Emuwren
+Stizoptera bichenovii_Double-barred Finch
+Stomiopera unicolor_White-gaped Honeyeater
+Strepera fuliginosa_Black Currawong
+Strepera graculina_Pied Currawong
+Strepera versicolor_Grey Currawong
+Streptopelia capicola_Ring-necked Dove
+Streptopelia chinensis_Spotted Dove
+Streptopelia decaocto_Collared Dove
+Streptopelia decipiens_Mourning Collared Dove
+Streptopelia lugens_Dusky Turtle Dove
+Streptopelia orientalis_Rufous Turtle Dove
+Streptopelia roseogrisea_African Collared Dove
+Streptopelia semitorquata_Red-eyed Dove
+Streptopelia senegalensis_Laughing Dove
+Streptopelia tranquebarica_Red Collared Dove
+Streptopelia turtur_European Turtle Dove
+Streptopelia vinacea_Vinaceous Dove
+Streptoprocne biscutata_Biscutate Swift
+Streptoprocne rutila_Chestnut-collared Swift
+Streptoprocne zonaris_White-collared Swift
+Strix aluco_Tawny Owl
+Strix chacoensis_Chaco Owl
+Strix fulvescens_Fulvous Owl
+Strix hadorami_Desert Owl
+Strix hylophila_Rusty-barred Owl
+Strix leptogrammica_Brown Wood-Owl
+Strix nebulosa_Great Grey Owl
+Strix nivicolum_Himalayan Owl
+Strix occidentalis_Spotted Owl
+Strix ocellata_Mottled Wood-Owl
+Strix rufipes_Rufous-legged Owl
+Strix seloputo_Spotted Wood-Owl
+Strix uralensis_Ural Owl
+Strix varia_Barred Owl
+Strix woodfordii_African Wood-Owl
+Struthidea cinerea_Apostlebird
+Sturnella magna_Eastern Meadowlark
+Sturnella neglecta_Western Meadowlark
+Sturnia blythii_Malabar Starling
+Sturnia malabarica_Chestnut-tailed Starling
+Sturnia pagodarum_Brahminy Starling
+Sturnia sinensis_White-shouldered Starling
+Sturnus unicolor_Spotless Starling
+Sturnus vulgaris_Common Starling
+Sublegatus arenarum_Northern Scrub-Flycatcher
+Sublegatus modestus_Southern Scrub-Flycatcher
+Sublegatus obscurior_Amazonian Scrub-Flycatcher
+Sugomel nigrum_Black Honeyeater
+Suiriri suiriri_Suiriri Flycatcher
+Sula dactylatra_Masked Booby
+Sula leucogaster_Brown Booby
+Sula nebouxii_Blue-footed Booby
+Sula sula_Red-footed Booby
+Surnia ulula_Northern Hawk Owl
+Surniculus dicruroides_Fork-tailed Drongo-Cuckoo
+Surniculus lugubris_Square-tailed Drongo-Cuckoo
+Surniculus velutinus_Philippine Drongo-Cuckoo
+Suthora nipalensis_Black-throated Parrotbill
+Suthora verreauxi_Golden Parrotbill
+Swynnertonia swynnertoni_Swynnerton's Robin
+Sylvia abyssinica_African Hill Babbler
+Sylvia atricapilla_Eurasian Blackcap
+Sylvia atriceps_Rwenzori Hill Babbler
+Sylvia borin_Garden Warbler
+Sylvia nigricapillus_Bush Blackcap
+Sylvietta brachyura_Northern Crombec
+Sylvietta rufescens_Cape Crombec
+Sylvietta ruficapilla_Red-capped Crombec
+Sylvietta virens_Green Crombec
+Sylvietta whytii_Red-faced Crombec
+Sylviorthorhynchus desmursii_Des Murs's Wiretail
+Sylviorthorhynchus yanacensis_Tawny Tit-Spinetail
+Sylviparus modestus_Yellow-browed Tit
+Syma torotoro_Yellow-billed Kingfisher
+Symposiachrus trivirgatus_Spectacled Monarch
+Synallaxis albescens_Pale-breasted Spinetail
+Synallaxis albigularis_Dark-breasted Spinetail
+Synallaxis albilora_White-lored Spinetail
+Synallaxis azarae_Azara's Spinetail
+Synallaxis brachyura_Slaty Spinetail
+Synallaxis cabanisi_Cabanis's Spinetail
+Synallaxis candei_White-whiskered Spinetail
+Synallaxis castanea_Black-throated Spinetail
+Synallaxis cherriei_Chestnut-throated Spinetail
+Synallaxis cinerascens_Grey-bellied Spinetail
+Synallaxis cinerea_Bahia Spinetail
+Synallaxis cinnamomea_Stripe-breasted Spinetail
+Synallaxis courseni_Apurimac Spinetail
+Synallaxis erythrothorax_Rufous-breasted Spinetail
+Synallaxis frontalis_Sooty-fronted Spinetail
+Synallaxis fuscorufa_Rusty-headed Spinetail
+Synallaxis gujanensis_Plain-crowned Spinetail
+Synallaxis hellmayri_Red-shouldered Spinetail
+Synallaxis hypochondriaca_Great Spinetail
+Synallaxis hypospodia_Cinereous-breasted Spinetail
+Synallaxis infuscata_Pinto's Spinetail
+Synallaxis kollari_Hoary-throated Spinetail
+Synallaxis macconnelli_McConnell's Spinetail
+Synallaxis maranonica_Marañon Spinetail
+Synallaxis moesta_Dusky Spinetail
+Synallaxis ruficapilla_Rufous-capped Spinetail
+Synallaxis rutilans_Ruddy Spinetail
+Synallaxis scutata_Ochre-cheeked Spinetail
+Synallaxis spixi_Spix's Spinetail
+Synallaxis stictothorax_Necklaced Spinetail
+Synallaxis subpudica_Silvery-throated Spinetail
+Synallaxis tithys_Blackish-headed Spinetail
+Synallaxis unirufa_Rufous Spinetail
+Syndactyla dimidiata_Russet-mantled Foliage-gleaner
+Syndactyla guttulata_Guttulate Foliage-gleaner
+Syndactyla ruficollis_Rufous-necked Foliage-gleaner
+Syndactyla rufosuperciliata_Buff-browed Foliage-gleaner
+Syndactyla striata_Bolivian Recurvebill
+Syndactyla subalaris_Lineated Foliage-gleaner
+Syndactyla ucayalae_Peruvian Recurvebill
+Synoicus chinensis_Blue-breasted Quail
+Synoicus ypsilophorus_Brown Quail
+Syrigma sibilatrix_Whistling Heron
+Syrrhaptes paradoxus_Pallas's Sandgrouse
+Systellura decussata_Tschudi's Nightjar
+Systellura longirostris_Band-winged Nightjar
+Taccocua leschenaultii_Sirkeer Malkoha
+Tachornis phoenicobia_Antillean Palm Swift
+Tachornis squamata_Fork-tailed Palm Swift
+Tachuris rubrigastra_Many-coloured Rush Tyrant
+Tachybaptus dominicus_Least Grebe
+Tachybaptus novaehollandiae_Australasian Grebe
+Tachybaptus ruficollis_Little Grebe
+Tachycineta albilinea_Mangrove Swallow
+Tachycineta albiventer_White-winged Swallow
+Tachycineta bicolor_Tree Swallow
+Tachycineta euchrysea_Golden Swallow
+Tachycineta leucopyga_Chilean Swallow
+Tachycineta leucorrhoa_White-rumped Swallow
+Tachycineta thalassina_Violet-green Swallow
+Tachyeres patachonicus_Flying Steamer-Duck
+Tachyphonus coronatus_Ruby-crowned Tanager
+Tachyphonus delatrii_Tawny-crested Tanager
+Tachyphonus phoenicius_Red-shouldered Tanager
+Tachyphonus rufus_White-lined Tanager
+Tachyphonus surinamus_Fulvous-crested Tanager
+Tadorna cana_South African Shelduck
+Tadorna ferruginea_Ruddy Shelduck
+Tadorna tadorna_Common Shelduck
+Tadorna tadornoides_Australian Shelduck
+Tadorna variegata_Paradise Shelduck
+Taenioptynx brodiei_Collared Owlet
+Taeniopygia guttata_Zebra Finch
+Taeniotriccus andrei_Black-chested Tyrant
+Talaphorus chlorocercus_Olive-spotted Hummingbird
+Talegalla fuscirostris_Yellow-legged Brushturkey
+Talegalla jobiensis_Red-legged Brushturkey
+Tamias striatus_Eastern Chipmunk
+Tamiasciurus hudsonicus_Red Squirrel
+Tangara arthus_Golden Tanager
+Tangara chilensis_Paradise Tanager
+Tangara cyanocephala_Red-necked Tanager
+Tangara cyanoventris_Gilt-edged Tanager
+Tangara desmaresti_Brassy-breasted Tanager
+Tangara dowii_Spangle-cheeked Tanager
+Tangara florida_Emerald Tanager
+Tangara gyrola_Bay-headed Tanager
+Tangara icterocephala_Silver-throated Tanager
+Tangara inornata_Plain-coloured Tanager
+Tangara labradorides_Metallic-green Tanager
+Tangara lavinia_Rufous-winged Tanager
+Tangara mexicana_Turquoise Tanager
+Tangara nigroviridis_Beryl-spangled Tanager
+Tangara parzudakii_Flame-faced Tanager
+Tangara schrankii_Green-and-gold Tanager
+Tangara seledon_Green-headed Tanager
+Tangara vassorii_Blue-and-black Tanager
+Tangara velia_Opal-rumped Tanager
+Tangara xanthocephala_Saffron-crowned Tanager
+Tanygnathus sumatranus_Azure-rumped Parrot
+Tanysiptera galatea_Common Paradise-Kingfisher
+Tanysiptera sylvia_Buff-breasted Paradise-Kingfisher
+Tapera naevia_Striped Cuckoo
+Taraba major_Great Antshrike
+Tarphonomus certhioides_Chaco Earthcreeper
+Tarphonomus harterti_Bolivian Earthcreeper
+Tarsiger chrysaeus_Golden Bush-Robin
+Tarsiger cyanurus_Red-flanked Bluetail
+Tarsiger indicus_White-browed Bush-Robin
+Tarsiger johnstoniae_Collared Bush-Robin
+Tarsiger rufilatus_Himalayan Bluetail
+Tauraco corythaix_Knysna Turaco
+Tauraco fischeri_Fischer's Turaco
+Tauraco hartlaubi_Hartlaub's Turaco
+Tauraco leucotis_White-cheeked Turaco
+Tauraco livingstonii_Livingstone's Turaco
+Tauraco macrorhynchus_Yellow-billed Turaco
+Tauraco persa_Guinea Turaco
+Tauraco porphyreolophus_Purple-crested Turaco
+Tauraco schalowi_Schalow's Turaco
+Tchagra australis_Brown-crowned Tchagra
+Tchagra senegalus_Black-crowned Tchagra
+Tchagra tchagra_Southern Tchagra
+Teledromas fuscus_Sandy Gallito
+Telespiza ultima_Nihoa Finch
+Telophorus bocagei_Grey-green Bushshrike
+Telophorus dohertyi_Doherty's Bushshrike
+Telophorus nigrifrons_Black-fronted Bushshrike
+Telophorus olivaceus_Olive Bushshrike
+Telophorus sulfureopectus_Sulphur-breasted Bushshrike
+Telophorus viridis_Four-coloured Bushshrike
+Telophorus zeylonus_Bokmakierie
+Temnurus temnurus_Ratchet-tailed Treepie
+Tephrodornis pondicerianus_Common Woodshrike
+Tephrodornis sylvicola_Malabar Woodshrike
+Tephrodornis virgatus_Large Woodshrike
+Terenotriccus erythrurus_Ruddy-tailed Flycatcher
+Terenura maculata_Streak-capped Antwren
+Terenura sicki_Orange-bellied Antwren
+Teretistris fernandinae_Yellow-headed Warbler
+Teretistris fornsi_Oriente Warbler
+Terpsiphone affinis_Blyth's Paradise-Flycatcher
+Terpsiphone atrocaudata_Black Paradise-Flycatcher
+Terpsiphone bourbonnensis_Mascarene Paradise-Flycatcher
+Terpsiphone cinnamomea_Rufous Paradise-Flycatcher
+Terpsiphone incei_Amur Paradise-Flycatcher
+Terpsiphone mutata_Malagasy Paradise-Flycatcher
+Terpsiphone paradisi_Indian Paradise-Flycatcher
+Terpsiphone rufiventer_Black-headed Paradise-Flycatcher
+Terpsiphone viridis_African Paradise-Flycatcher
+Tersina viridis_Swallow Tanager
+Tesia cyaniventer_Grey-bellied Tesia
+Tesia everetti_Russet-capped Tesia
+Tesia olivea_Slaty-bellied Tesia
+Tesia superciliaris_Javan Tesia
+Tetrao urogallus_Western Capercaillie
+Tetraogallus caucasicus_Caucasian Snowcock
+Tetraogallus tibetanus_Tibetan Snowcock
+Tetrastes bonasia_Hazel Grouse
+Tetrax tetrax_Little Bustard
+Thalassarche melanophris_Black-browed Albatross
+Thalasseus bengalensis_Lesser Crested Tern
+Thalasseus bergii_Great Crested Tern
+Thalasseus elegans_Elegant Tern
+Thalasseus maximus_Royal Tern
+Thalasseus sandvicensis_Sandwich Tern
+Thalurania colombica_Crowned Woodnymph
+Thalurania furcata_Fork-tailed Woodnymph
+Thalurania glaucopis_Violet-capped Woodnymph
+Thamnistes anabatinus_Russet Antshrike
+Thamnolaea cinnamomeiventris_Mocking Cliff-Chat
+Thamnomanes ardesiacus_Dusky-throated Antshrike
+Thamnomanes caesius_Cinereous Antshrike
+Thamnomanes saturninus_Saturnine Antshrike
+Thamnomanes schistogynus_Bluish-slate Antshrike
+Thamnophilus aethiops_White-shouldered Antshrike
+Thamnophilus amazonicus_Amazonian Antshrike
+Thamnophilus ambiguus_Sooretama Slaty-Antshrike
+Thamnophilus aroyae_Upland Antshrike
+Thamnophilus atrinucha_Black-crowned Antshrike
+Thamnophilus bernardi_Collared Antshrike
+Thamnophilus bridgesi_Black-hooded Antshrike
+Thamnophilus caerulescens_Variable Antshrike
+Thamnophilus cryptoleucus_Castelnau's Antshrike
+Thamnophilus doliatus_Barred Antshrike
+Thamnophilus melanonotus_Black-backed Antshrike
+Thamnophilus multistriatus_Bar-crested Antshrike
+Thamnophilus murinus_Mouse-coloured Antshrike
+Thamnophilus nigriceps_Black Antshrike
+Thamnophilus nigrocinereus_Blackish-grey Antshrike
+Thamnophilus palliatus_Chestnut-backed Antshrike
+Thamnophilus pelzelni_Planalto Slaty-Antshrike
+Thamnophilus praecox_Cocha Antshrike
+Thamnophilus punctatus_Northern Slaty-Antshrike
+Thamnophilus ruficapillus_Rufous-capped Antshrike
+Thamnophilus schistaceus_Plain-winged Antshrike
+Thamnophilus stictocephalus_Natterer's Slaty-Antshrike
+Thamnophilus sticturus_Bolivian Slaty-Antshrike
+Thamnophilus tenuepunctatus_Lined Antshrike
+Thamnophilus torquatus_Rufous-winged Antshrike
+Thamnophilus unicolor_Uniform Antshrike
+Thamnophilus zarumae_Chapman's Antshrike
+Thectocercus acuticaudatus_Blue-crowned Parakeet
+Theristicus caerulescens_Plumbeous Ibis
+Theristicus caudatus_Buff-necked Ibis
+Theristicus melanopis_Black-faced Ibis
+Thescelocichla leucopleura_Swamp Greenbul
+Thinocorus orbignyianus_Grey-breasted Seedsnipe
+Thinocorus rumicivorus_Least Seedsnipe
+Thlypopsis ornata_Rufous-chested Tanager
+Thlypopsis pyrrhocoma_Chestnut-headed Tanager
+Thlypopsis sordida_Orange-headed Tanager
+Thlypopsis superciliaris_Superciliaried Hemispingus
+Thraupis abbas_Yellow-winged Tanager
+Thraupis cyanoptera_Azure-shouldered Tanager
+Thraupis episcopus_Blue-grey Tanager
+Thraupis ornata_Golden-chevroned Tanager
+Thraupis palmarum_Palm Tanager
+Thraupis sayaca_Sayaca Tanager
+Threnetes leucurus_Pale-tailed Barbthroat
+Threnetes ruckeri_Band-tailed Barbthroat
+Threskiornis melanocephalus_Black-headed Ibis
+Threskiornis molucca_Australian Ibis
+Thripadectes flammulatus_Flammulated Treehunter
+Thripadectes holostictus_Striped Treehunter
+Thripadectes ignobilis_Uniform Treehunter
+Thripadectes melanorhynchus_Black-billed Treehunter
+Thripadectes rufobrunneus_Streak-breasted Treehunter
+Thripadectes scrutator_Rufous-backed Treehunter
+Thripadectes virgaticeps_Streak-capped Treehunter
+Thripophaga cherriei_Orinoco Softtail
+Thripophaga fusciceps_Plain Softtail
+Thripophaga macroura_Striated Softtail
+Thryomanes bewickii_Bewick's Wren
+Thryophilus nicefori_Niceforo's Wren
+Thryophilus pleurostictus_Banded Wren
+Thryophilus rufalbus_Rufous-and-white Wren
+Thryophilus sernai_Antioquia Wren
+Thryophilus sinaloa_Sinaloa Wren
+Thryothorus ludovicianus_Carolina Wren
+Tiaris olivaceus_Yellow-faced Grassquit
+Tichodroma muraria_Wallcreeper
+Tickellia hodgsoni_Broad-billed Warbler
+Tigrisoma lineatum_Rufescent Tiger-Heron
+Tigrisoma mexicanum_Bare-throated Tiger-Heron
+Timalia pileata_Chestnut-capped Babbler
+Tinamotis pentlandii_Puna Tinamou
+Tinamus guttatus_White-throated Tinamou
+Tinamus major_Great Tinamou
+Tinamus solitarius_Solitary Tinamou
+Tinamus tao_Grey Tinamou
+Tityra cayana_Black-tailed Tityra
+Tityra inquisitor_Black-crowned Tityra
+Tityra semifasciata_Masked Tityra
+Tockus deckeni_Von der Decken's Hornbill
+Tockus erythrorhynchus_Northern Red-billed Hornbill
+Tockus kempi_Western Red-billed Hornbill
+Tockus leucomelas_Southern Yellow-billed Hornbill
+Tockus rufirostris_Southern Red-billed Hornbill
+Todiramphus australasia_Cinnamon-banded Kingfisher
+Todiramphus chloris_Collared Kingfisher
+Todiramphus funebris_Sombre Kingfisher
+Todiramphus macleayii_Forest Kingfisher
+Todiramphus sacer_Pacific Kingfisher
+Todiramphus sanctus_Sacred Kingfisher
+Todiramphus sordidus_Torresian Kingfisher
+Todiramphus tristrami_Melanesian Kingfisher
+Todiramphus winchelli_Rufous-lored Kingfisher
+Todirostrum chrysocrotaphum_Yellow-browed Tody-Flycatcher
+Todirostrum cinereum_Common Tody-Flycatcher
+Todirostrum maculatum_Spotted Tody-Flycatcher
+Todirostrum nigriceps_Black-headed Tody-Flycatcher
+Todirostrum pictum_Painted Tody-Flycatcher
+Todirostrum poliocephalum_Grey-headed Tody-Flycatcher
+Todus angustirostris_Narrow-billed Tody
+Todus mexicanus_Puerto Rican Tody
+Todus multicolor_Cuban Tody
+Todus subulatus_Broad-billed Tody
+Todus todus_Jamaican Tody
+Tolmomyias assimilis_Yellow-margined Flatbill
+Tolmomyias flaviventris_Ochre-lored Flatbill
+Tolmomyias poliocephalus_Grey-crowned Flatbill
+Tolmomyias sulphurescens_Yellow-olive Flatbill
+Tolmomyias traylori_Orange-eyed Flatbill
+Topaza pella_Crimson Topaz
+Topaza pyra_Fiery Topaz
+Torreornis inexpectata_Zapata Sparrow
+Touit batavicus_Lilac-tailed Parrotlet
+Touit dilectissimus_Blue-fronted Parrotlet
+Touit huetii_Scarlet-shouldered Parrotlet
+Touit melanonotus_Brown-backed Parrotlet
+Touit purpuratus_Sapphire-rumped Parrotlet
+Touit stictopterus_Spot-winged Parrotlet
+Touit surdus_Golden-tailed Parrotlet
+Toxorhamphus novaeguineae_Yellow-bellied Longbill
+Toxostoma bendirei_Bendire's Thrasher
+Toxostoma cinereum_Grey Thrasher
+Toxostoma crissale_Crissal Thrasher
+Toxostoma curvirostre_Curve-billed Thrasher
+Toxostoma lecontei_LeConte's Thrasher
+Toxostoma longirostre_Long-billed Thrasher
+Toxostoma ocellatum_Ocellated Thrasher
+Toxostoma redivivum_California Thrasher
+Toxostoma rufum_Brown Thrasher
+Trachyphonus darnaudii_D'Arnaud's Barbet
+Trachyphonus erythrocephalus_Red-and-yellow Barbet
+Trachyphonus purpuratus_Yellow-billed Barbet
+Trachyphonus vaillantii_Crested Barbet
+Tregellasia capito_Pale-yellow Robin
+Treron affinis_Grey-fronted Green-Pigeon
+Treron bicinctus_Orange-breasted Green-Pigeon
+Treron calvus_African Green-Pigeon
+Treron curvirostra_Thick-billed Green-Pigeon
+Treron formosae_Whistling Green-Pigeon
+Treron fulvicollis_Cinnamon-headed Green-Pigeon
+Treron olax_Little Green-Pigeon
+Treron phayrei_Ashy-headed Green-Pigeon
+Treron phoenicopterus_Yellow-footed Green-Pigeon
+Treron sieboldii_White-bellied Green-Pigeon
+Treron sphenurus_Wedge-tailed Green-Pigeon
+Treron vernans_Pink-necked Green-Pigeon
+Tribonyx mortierii_Tasmanian Nativehen
+Tribonyx ventralis_Black-tailed Nativehen
+Trichoglossus chlorolepidotus_Scaly-breasted Lorikeet
+Trichoglossus haematodus_Coconut Lorikeet
+Trichoglossus moluccanus_Rainbow Lorikeet
+Trichoglossus rubritorquis_Red-collared Lorikeet
+Tricholaema diademata_Red-fronted Barbet
+Tricholaema hirsuta_Hairy-breasted Barbet
+Tricholaema lacrymosa_Spot-flanked Barbet
+Tricholaema leucomelas_Pied Barbet
+Tricholaema melanocephala_Black-throated Barbet
+Tricholestes criniger_Hairy-backed Bulbul
+Trichothraupis melanops_Black-goggled Tanager
+Triclaria malachitacea_Blue-bellied Parrot
+Tringa brevipes_Grey-tailed Tattler
+Tringa erythropus_Spotted Redshank
+Tringa flavipes_Lesser Yellowlegs
+Tringa glareola_Wood Sandpiper
+Tringa guttifer_Nordmann's Greenshank
+Tringa incana_Wandering Tattler
+Tringa melanoleuca_Greater Yellowlegs
+Tringa nebularia_Common Greenshank
+Tringa ochropus_Green Sandpiper
+Tringa semipalmata_Willet
+Tringa solitaria_Solitary Sandpiper
+Tringa stagnatilis_Marsh Sandpiper
+Tringa totanus_Common Redshank
+Trochalopteron affine_Black-faced Laughingthrush
+Trochalopteron chrysopterum_Assam Laughingthrush
+Trochalopteron elliotii_Elliot's Laughingthrush
+Trochalopteron erythrocephalum_Chestnut-crowned Laughingthrush
+Trochalopteron henrici_Prince Henry's Laughingthrush
+Trochalopteron imbricatum_Bhutan Laughingthrush
+Trochalopteron lineatum_Streaked Laughingthrush
+Trochalopteron melanostigma_Silver-eared Laughingthrush
+Trochalopteron milnei_Red-tailed Laughingthrush
+Trochalopteron morrisonianum_White-whiskered Laughingthrush
+Trochalopteron peninsulae_Malayan Laughingthrush
+Trochalopteron squamatum_Blue-winged Laughingthrush
+Trochalopteron subunicolor_Scaly Laughingthrush
+Trochalopteron variegatum_Variegated Laughingthrush
+Trochalopteron virgatum_Striped Laughingthrush
+Trochocercus cyanomelas_African Crested Flycatcher
+Trochocercus nitens_Blue-headed Crested Flycatcher
+Troglodytes aedon_House Wren
+Troglodytes hiemalis_Winter Wren
+Troglodytes ochraceus_Ochraceous Wren
+Troglodytes pacificus_Pacific Wren
+Troglodytes rufociliatus_Rufous-browed Wren
+Troglodytes solstitialis_Mountain Wren
+Troglodytes troglodytes_Eurasian Wren
+Trogon bairdii_Baird's Trogon
+Trogon caligatus_Gartered Trogon
+Trogon chionurus_White-tailed Trogon
+Trogon citreolus_Citreoline Trogon
+Trogon clathratus_Lattice-tailed Trogon
+Trogon collaris_Collared Trogon
+Trogon comptus_Blue-tailed Trogon
+Trogon curucui_Blue-crowned Trogon
+Trogon elegans_Elegant Trogon
+Trogon massena_Slaty-tailed Trogon
+Trogon melanocephalus_Black-headed Trogon
+Trogon melanurus_Black-tailed Trogon
+Trogon mesurus_Ecuadorian Trogon
+Trogon mexicanus_Mountain Trogon
+Trogon personatus_Masked Trogon
+Trogon ramonianus_Amazonian Trogon
+Trogon rufus_Amazonian Black-throated Trogon
+Trogon surrucura_Surucua Trogon
+Trogon violaceus_Guianan Trogon
+Trogon viridis_Green-backed Trogon
+Tropicoperdix chloropus_Scaly-breasted Partridge
+Tumbezia salvini_Tumbes Tyrant
+Tunchiornis ochraceiceps_Tawny-crowned Greenlet
+Turdinus atrigularis_Black-throated Wren-Babbler
+Turdinus macrodactylus_Large Wren-Babbler
+Turdinus marmoratus_Marbled Wren-Babbler
+Turdoides hartlaubii_Hartlaub's Babbler
+Turdoides jardineii_Arrow-marked Babbler
+Turdoides leucopygia_White-rumped Babbler
+Turdoides plebejus_Brown Babbler
+Turdoides reinwardtii_Blackcap Babbler
+Turdoides sharpei_Black-lored Babbler
+Turdus abyssinicus_Abyssinian Thrush
+Turdus albicollis_White-necked Thrush
+Turdus albocinctus_White-collared Blackbird
+Turdus amaurochalinus_Creamy-bellied Thrush
+Turdus assimilis_White-throated Thrush
+Turdus atrogularis_Black-throated Thrush
+Turdus aurantius_White-chinned Thrush
+Turdus boulboul_Grey-winged Blackbird
+Turdus cardis_Japanese Thrush
+Turdus celaenops_Izu Thrush
+Turdus chiguanco_Chiguanco Thrush
+Turdus chrysolaus_Brown-headed Thrush
+Turdus dissimilis_Black-breasted Thrush
+Turdus eunomus_Dusky Thrush
+Turdus falcklandii_Austral Thrush
+Turdus feae_Grey-sided Thrush
+Turdus flavipes_Yellow-legged Thrush
+Turdus fulviventris_Chestnut-bellied Thrush
+Turdus fumigatus_Cocoa Thrush
+Turdus fuscater_Great Thrush
+Turdus grayi_Clay-coloured Thrush
+Turdus hauxwelli_Hauxwell's Thrush
+Turdus hortulorum_Grey-backed Thrush
+Turdus ignobilis_Black-billed Thrush
+Turdus iliacus_Redwing
+Turdus infuscatus_Black Thrush
+Turdus lawrencii_Lawrence's Thrush
+Turdus leucomelas_Pale-breasted Thrush
+Turdus leucops_Pale-eyed Thrush
+Turdus libonyana_Kurrichane Thrush
+Turdus maculirostris_Ecuadorian Thrush
+Turdus mandarinus_Chinese Blackbird
+Turdus maranonicus_Marañon Thrush
+Turdus menachensis_Yemen Thrush
+Turdus merula_Eurasian Blackbird
+Turdus migratorius_American Robin
+Turdus naumanni_Naumann's Thrush
+Turdus nigrescens_Sooty Thrush
+Turdus nigriceps_Andean Slaty Thrush
+Turdus nudigenis_Spectacled Thrush
+Turdus obscurus_Eyebrowed Thrush
+Turdus obsoletus_Pale-vented Thrush
+Turdus olivaceus_Olive Thrush
+Turdus olivater_Black-hooded Thrush
+Turdus pallidus_Pale Thrush
+Turdus pelios_African Thrush
+Turdus philomelos_Song Thrush
+Turdus pilaris_Fieldfare
+Turdus plebejus_Mountain Thrush
+Turdus plumbeus_Red-legged Thrush
+Turdus poliocephalus_Island Thrush
+Turdus reevei_Plumbeous-backed Thrush
+Turdus rubrocanus_Chestnut Thrush
+Turdus ruficollis_Red-throated Thrush
+Turdus rufitorques_Rufous-collared Robin
+Turdus rufiventris_Rufous-bellied Thrush
+Turdus rufopalliatus_Rufous-backed Robin
+Turdus sanchezorum_Varzea Thrush
+Turdus serranus_Glossy-black Thrush
+Turdus simillimus_Indian Blackbird
+Turdus smithi_Karoo Thrush
+Turdus subalaris_Blacksmith Thrush
+Turdus swalesi_La Selle Thrush
+Turdus tephronotus_African Bare-eyed Thrush
+Turdus torquatus_Ring Ouzel
+Turdus unicolor_Tickell's Thrush
+Turdus viscivorus_Mistle Thrush
+Turnix maculosus_Red-backed Buttonquail
+Turnix suscitator_Barred Buttonquail
+Turnix sylvaticus_Small Buttonquail
+Turnix varius_Painted Buttonquail
+Turtur abyssinicus_Black-billed Wood-Dove
+Turtur afer_Blue-spotted Wood-Dove
+Turtur brehmeri_Blue-headed Wood-Dove
+Turtur chalcospilos_Emerald-spotted Wood-Dove
+Turtur tympanistria_Tambourine Dove
+Tylas eduardi_Tylas Vanga
+Tympanuchus cupido_Greater Prairie-Chicken
+Tympanuchus pallidicinctus_Lesser Prairie-Chicken
+Tympanuchus phasianellus_Sharp-tailed Grouse
+Tyranneutes stolzmanni_Dwarf Tyrant-Manakin
+Tyranneutes virescens_Tiny Tyrant-Manakin
+Tyrannopsis sulphurea_Sulphury Flycatcher
+Tyrannulus elatus_Yellow-crowned Tyrannulet
+Tyrannus albogularis_White-throated Kingbird
+Tyrannus caudifasciatus_Loggerhead Kingbird
+Tyrannus couchii_Couch's Kingbird
+Tyrannus crassirostris_Thick-billed Kingbird
+Tyrannus dominicensis_Grey Kingbird
+Tyrannus forficatus_Scissor-tailed Flycatcher
+Tyrannus melancholicus_Tropical Kingbird
+Tyrannus niveigularis_Snowy-throated Kingbird
+Tyrannus savana_Fork-tailed Flycatcher
+Tyrannus tyrannus_Eastern Kingbird
+Tyrannus verticalis_Western Kingbird
+Tyrannus vociferans_Cassin's Kingbird
+Tyto alba_Barn Owl
+Tyto novaehollandiae_Australian Masked-Owl
+Tyto tenebricosa_Sooty Owl
+Upucerthia dumetaria_Scale-throated Earthcreeper
+Upucerthia saturatior_Patagonian Forest Earthcreeper
+Upucerthia validirostris_Buff-breasted Earthcreeper
+Upupa epops_Eurasian Hoopoe
+Upupa marginata_Madagascar Hoopoe
+Uraeginthus angolensis_Southern Cordonbleu
+Uraeginthus bengalus_Red-cheeked Cordonbleu
+Uranomitra franciae_Andean Emerald
+Uria aalge_Common Guillemot
+Uria lomvia_Brünnich's Guillemot
+Urocissa caerulea_Taiwan Blue-Magpie
+Urocissa erythroryncha_Red-billed Blue-Magpie
+Urocissa flavirostris_Yellow-billed Blue-Magpie
+Urocissa ornata_Sri Lanka Blue-Magpie
+Urocolius indicus_Red-faced Mousebird
+Urocolius macrourus_Blue-naped Mousebird
+Urocynchramus pylzowi_Przevalski's Pinktail
+Urodynamis taitensis_Long-tailed Koel
+Uromyias agilis_Agile Tit-Tyrant
+Uromyias agraphia_Unstreaked Tit-Tyrant
+Uropsalis lyra_Lyre-tailed Nightjar
+Uropsalis segmentata_Swallow-tailed Nightjar
+Uropsila leucogastra_White-bellied Wren
+Urosphena pallidipes_Pale-footed Bush Warbler
+Urosphena squameiceps_Asian Stubtail
+Urosphena subulata_Timor Stubtail
+Urosphena whiteheadi_Bornean Stubtail
+Urothraupis stolzmanni_Black-backed Bush Tanager
+Urotriorchis macrourus_Long-tailed Hawk
+Vanellus armatus_Blacksmith Lapwing
+Vanellus cayanus_Pied Lapwing
+Vanellus chilensis_Southern Lapwing
+Vanellus cinereus_Grey-headed Lapwing
+Vanellus coronatus_Crowned Lapwing
+Vanellus duvaucelii_River Lapwing
+Vanellus indicus_Red-wattled Lapwing
+Vanellus leucurus_White-tailed Lapwing
+Vanellus malabaricus_Yellow-wattled Lapwing
+Vanellus melanocephalus_Spot-breasted Lapwing
+Vanellus melanopterus_Black-winged Lapwing
+Vanellus miles_Masked Lapwing
+Vanellus resplendens_Andean Lapwing
+Vanellus senegallus_Wattled Lapwing
+Vanellus spinosus_Spur-winged Lapwing
+Vanellus tectus_Black-headed Lapwing
+Vanellus tricolor_Banded Lapwing
+Vanellus vanellus_Northern Lapwing
+Vanga curvirostris_Hook-billed Vanga
+Vermivora chrysoptera_Golden-winged Warbler
+Vermivora cyanoptera_Blue-winged Warbler
+Vidua chalybeata_Village Indigobird
+Vidua fischeri_Straw-tailed Whydah
+Vidua funerea_Variable Indigobird
+Vidua macroura_Pin-tailed Whydah
+Vireo altiloquus_Black-whiskered Vireo
+Vireo atricapilla_Black-capped Vireo
+Vireo bairdi_Cozumel Vireo
+Vireo bellii_Bell's Vireo
+Vireo brevipennis_Slaty Vireo
+Vireo carmioli_Yellow-winged Vireo
+Vireo cassinii_Cassin's Vireo
+Vireo chivi_Chivi Vireo
+Vireo crassirostris_Thick-billed Vireo
+Vireo flavifrons_Yellow-throated Vireo
+Vireo flavoviridis_Yellow-green Vireo
+Vireo gilvus_Warbling Vireo
+Vireo gracilirostris_Noronha Vireo
+Vireo griseus_White-eyed Vireo
+Vireo gundlachii_Cuban Vireo
+Vireo huttoni_Hutton's Vireo
+Vireo hypochryseus_Golden Vireo
+Vireo latimeri_Puerto Rican Vireo
+Vireo leucophrys_Brown-capped Vireo
+Vireo magister_Yucatan Vireo
+Vireo masteri_Choco Vireo
+Vireo modestus_Jamaican Vireo
+Vireo nelsoni_Dwarf Vireo
+Vireo olivaceus_Red-eyed Vireo
+Vireo pallens_Mangrove Vireo
+Vireo philadelphicus_Philadelphia Vireo
+Vireo plumbeus_Plumbeous Vireo
+Vireo sclateri_Tepui Vireo
+Vireo solitarius_Blue-headed Vireo
+Vireo vicinior_Grey Vireo
+Vireolanius eximius_Yellow-browed Shrike-Vireo
+Vireolanius leucotis_Slaty-capped Shrike-Vireo
+Vireolanius melitophrys_Chestnut-sided Shrike-Vireo
+Vireolanius pulchellus_Green Shrike-Vireo
+Volatinia jacarina_Blue-black Grassquit
+Wetmorethraupis sterrhopteron_Orange-throated Tanager
+Willisornis poecilinotus_Common Scale-backed Antbird
+Willisornis vidua_Xingu Scale-backed Antbird
+Xanthocephalus xanthocephalus_Yellow-headed Blackbird
+Xanthomixis zosterops_Spectacled Tetraka
+Xanthopsar flavus_Saffron-cowled Blackbird
+Xanthotis macleayanus_Macleay's Honeyeater
+Xema sabini_Sabine's Gull
+Xenerpestes singularis_Equatorial Greytail
+Xenodacnis parina_Tit-like Dacnis
+Xenoglaux loweryi_Long-whiskered Owlet
+Xenopipo atronitens_Black Manakin
+Xenopirostris damii_Van Dam's Vanga
+Xenopirostris polleni_Pollen's Vanga
+Xenops minutus_Plain Xenops
+Xenops rutilans_Streaked Xenops
+Xenops tenuirostris_Slender-billed Xenops
+Xenopsaris albinucha_White-naped Xenopsaris
+Xenospiza baileyi_Sierra Madre Sparrow
+Xenotriccus callizonus_Belted Flycatcher
+Xenotriccus mexicanus_Pileated Flycatcher
+Xenus cinereus_Terek Sandpiper
+Xiphidiopicus percussus_Cuban Green Woodpecker
+Xiphocolaptes albicollis_White-throated Woodcreeper
+Xiphocolaptes major_Great Rufous Woodcreeper
+Xiphocolaptes promeropirhynchus_Strong-billed Woodcreeper
+Xipholena punicea_Pompadour Cotinga
+Xiphorhynchus elegans_Elegant Woodcreeper
+Xiphorhynchus erythropygius_Spotted Woodcreeper
+Xiphorhynchus flavigaster_Ivory-billed Woodcreeper
+Xiphorhynchus fuscus_Lesser Woodcreeper
+Xiphorhynchus guttatus_Buff-throated Woodcreeper
+Xiphorhynchus lachrymosus_Black-striped Woodcreeper
+Xiphorhynchus obsoletus_Striped Woodcreeper
+Xiphorhynchus ocellatus_Ocellated Woodcreeper
+Xiphorhynchus pardalotus_Chestnut-rumped Woodcreeper
+Xiphorhynchus spixii_Spix's Woodcreeper
+Xiphorhynchus susurrans_Cocoa Woodcreeper
+Xiphorhynchus triangularis_Olive-backed Woodcreeper
+Xolmis irupero_White Monjita
+Yuhina brunneiceps_Taiwan Yuhina
+Yuhina flavicollis_Whiskered Yuhina
+Yuhina gularis_Stripe-throated Yuhina
+Yuhina nigrimenta_Black-chinned Yuhina
+Yuhina occipitalis_Rufous-vented Yuhina
+Yungipicus canicapillus_Grey-capped Pygmy Woodpecker
+Yungipicus kizuki_Japanese Pygmy Woodpecker
+Yungipicus moluccensis_Sunda Pygmy Woodpecker
+Yungipicus nanus_Brown-capped Pygmy Woodpecker
+Zapornia bicolor_Black-tailed Crake
+Zapornia flavirostra_Black Crake
+Zapornia fusca_Ruddy-breasted Crake
+Zapornia parva_Little Crake
+Zapornia paykullii_Band-bellied Crake
+Zapornia pusilla_Baillon's Crake
+Zapornia tabuensis_Spotless Crake
+Zavattariornis stresemanni_Stresemann's Bush-Crow
+Zebrilus undulatus_Zigzag Heron
+Zeledonia coronata_Wrenthrush
+Zenaida asiatica_White-winged Dove
+Zenaida auriculata_Eared Dove
+Zenaida aurita_Zenaida Dove
+Zenaida macroura_Mourning Dove
+Zenaida meloda_West Peruvian Dove
+Zentrygon albifacies_White-faced Quail-Dove
+Zentrygon carrikeri_Tuxtla Quail-Dove
+Zentrygon frenata_White-throated Quail-Dove
+Zentrygon goldmani_Russet-crowned Quail-Dove
+Zentrygon lawrencii_Purplish-backed Quail-Dove
+Zentrygon linearis_Lined Quail-Dove
+Zimmerius acer_Guianan Tyrannulet
+Zimmerius albigularis_Choco Tyrannulet
+Zimmerius bolivianus_Bolivian Tyrannulet
+Zimmerius chrysops_Golden-faced Tyrannulet
+Zimmerius cinereicapilla_Red-billed Tyrannulet
+Zimmerius gracilipes_Slender-footed Tyrannulet
+Zimmerius parvus_Mistletoe Tyrannulet
+Zimmerius vilissimus_Guatemalan Tyrannulet
+Zimmerius villarejoi_Mishana Tyrannulet
+Zimmerius viridiflavus_Peruvian Tyrannulet
+Zonotrichia albicollis_White-throated Sparrow
+Zonotrichia atricapilla_Golden-crowned Sparrow
+Zonotrichia capensis_Rufous-collared Sparrow
+Zonotrichia leucophrys_White-crowned Sparrow
+Zonotrichia querula_Harris's Sparrow
+Zoothera aurea_White's Thrush
+Zoothera heinei_Russet-tailed Thrush
+Zoothera lunulata_Bassian Thrush
+Zoothera major_Amami Thrush
+Zosterops abyssinicus_Abyssinian White-eye
+Zosterops anderssoni_Southern Yellow White-eye
+Zosterops atricapilla_Black-capped White-eye
+Zosterops atriceps_Cream-throated White-eye
+Zosterops atrifrons_Black-crowned White-eye
+Zosterops auriventer_Hume's White-eye
+Zosterops ceylonensis_Sri Lanka White-eye
+Zosterops chloronothos_Mauritius White-eye
+Zosterops citrinella_Ashy-bellied White-eye
+Zosterops erythropleurus_Chestnut-flanked White-eye
+Zosterops eurycricotus_Kilimanjaro White-eye
+Zosterops everetti_Everett's White-eye
+Zosterops flavifrons_Yellow-fronted White-eye
+Zosterops flavilateralis_Pale White-eye
+Zosterops japonicus_Warbling White-eye
+Zosterops lateralis_Silvereye
+Zosterops luteus_Australian Yellow White-eye
+Zosterops maderaspatanus_Malagasy White-eye
+Zosterops mauritianus_Mauritius Grey White-eye
+Zosterops metcalfii_Yellow-throated White-eye
+Zosterops meyeni_Lowland White-eye
+Zosterops pallidus_Orange River White-eye
+Zosterops palpebrosus_Indian White-eye
+Zosterops senegalensis_Northern Yellow White-eye
+Zosterops simplex_Swinhoe's White-eye
+Zosterops virens_Cape White-eye

--- a/translate.py
+++ b/translate.py
@@ -11,8 +11,8 @@ import urllib.request
 import config as cfg
 import utils
 
-LOCALES = ['af', 'ar', 'cs', 'da', 'de', 'es', 'fi', 'fr', 'hu', 'it', 'ja', 'ko', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'uk', 'zh']
-""" Locales for 25 common languages (according to GitHub Copilot) """
+LOCALES = ['af', 'ar', 'cs', 'da', 'de', 'en_uk', 'es', 'fi', 'fr', 'hu', 'it', 'ja', 'ko', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'uk', 'zh']
+""" Locales for 26 common languages (according to GitHub Copilot) """
 
 API_TOKEN = "yourAPIToken"
 """ Sign up for your personal access token here: https://ebird.org/api/keygen """


### PR DESCRIPTION
BirdNET's English labels use US common names. This pull request adds UK common names to the list of locales. 

The benefit will be clarification, for UK users, that results for species like Anas Crecca "Green-winged Teal" are actually a merged clsas "Eurasian/Green-winged Teal", and "Brant" - a rarity in the UK, is actually a record for "Brent Goose". Other common names, such as "Eurasian Thick-knee" will be given their local name "Stone-curlew". Additionally, UK spellings are used for "Grey", rather than "Gray".

A new label file for en_uk has been added, and also the translate.py file has the "en_uk" locale in the LOCALES list. 

The eBird API download for the new locale has been tested and works, but the impact on the build for "BirdNET Analyzer GIU", whilst it should work,  has not been tested. I will defer to your exprerience on this, as I have not fathomed how it works.