### PR TITLE
Convert file duration to int

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -38,7 +38,7 @@ def getAudioFileLength(path, sample_rate=48000):
     # Open file with librosa (uses ffmpeg or libav)
     import librosa
 
-    return librosa.get_duration(filename=path, sr=sample_rate)
+    return int(librosa.get_duration(filename=path, sr=sample_rate))
 
 def get_sample_rate(path: str):
     import librosa


### PR DESCRIPTION
* we convert the fule duration to int, otherwise there might be a small leftover which cannot be read because of the sampling rate