### PR TITLE
updated call for keras function so its compatible with tensorflow 2.16.1

### DIFF
--- a/model.py
+++ b/model.py
@@ -249,7 +249,7 @@ def trainLinearClassifier(
     ]
 
     # Cosine annealing lr schedule
-    lr_schedule = keras.experimental.CosineDecay(learning_rate, epochs * x_train.shape[0] / batch_size)
+    lr_schedule = keras.optimizers.schedules.CosineDecay(learning_rate, epochs * x_train.shape[0] / batch_size)
 
     # Compile model
     classifier.compile(


### PR DESCRIPTION
I am using Birdnet for training models and I found that tensorflow version 2.16.1 changed keras module such as the current call in model.py failed. 

I found the fix by searching similar issues and looking at tf docs. 
**old version tf 1.15** -->  https://typeoverflow.com/developer/docs/tensorflow~1.15/keras/experimental/cosinedecay
tf.keras.experimental.CosineDecay(
    initial_learning_rate, decay_steps, alpha=0.0, name=None
)

**latest version 2.16.1** --> https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/schedules/CosineDecay
tf.keras.optimizers.schedules.CosineDecay(
    initial_learning_rate,
    decay_steps,
    alpha=0.0,
    name='CosineDecay',
    warmup_target=None,
    warmup_steps=0
)

there is more information about migrating to tf 2versions here: https://www.tensorflow.org/guide/migrate