### PR TITLE
Fix for combined Raven selection table

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -485,7 +485,7 @@ def analyzeFile(item):
     print(f"Analyzing {fpath}", flush=True)
 
     try:
-        fileLengthSeconds = audio.getAudioFileLength(fpath, cfg.SAMPLE_RATE)
+        fileLengthSeconds = int(audio.getAudioFileLength(fpath, cfg.SAMPLE_RATE))
     except Exception as ex:
         # Write error log
         print(f"Error: Cannot analyze audio file {fpath}. File corrupt?\n", flush=True)

--- a/audio.py
+++ b/audio.py
@@ -38,7 +38,7 @@ def getAudioFileLength(path, sample_rate=48000):
     # Open file with librosa (uses ffmpeg or libav)
     import librosa
 
-    return int(librosa.get_duration(filename=path, sr=sample_rate))
+    return librosa.get_duration(filename=path, sr=sample_rate)
 
 def get_sample_rate(path: str):
     import librosa

--- a/embeddings.py
+++ b/embeddings.py
@@ -47,7 +47,7 @@ def analyzeFile(item):
 
     offset = 0
     duration = cfg.FILE_SPLITTING_DURATION
-    fileLengthSeconds = audio.getAudioFileLength(fpath, cfg.SAMPLE_RATE)
+    fileLengthSeconds = int(audio.getAudioFileLength(fpath, cfg.SAMPLE_RATE))
     results = {}
 
     # Start time


### PR DESCRIPTION
audio file length only gets rounded (cast to int) for analysis/embeddings. this fixes the combined raven selection table