### PR TITLE
Updated Dockerfile using requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build from Python slim
-FROM python:3.11-slim
+FROM python:3.11
 
 # Install required packages while keeping the image small
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
-# Build from Python 3.8 slim
-FROM python:3.9-slim
+# Build from Python slim
+FROM python:3.11-slim
 
 # Install required packages while keeping the image small
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg  && rm -rf /var/lib/apt/lists/*
 
-# Install required Python packages
-RUN pip3 install numpy scipy librosa bottle resampy
-
-# Install Tensforflow
-RUN pip3 install tensorflow 
-
 # Import all scripts
 COPY . ./
+
+# Install required Python packages
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Add entry point to run the script
 ENTRYPOINT [ "python3" ]


### PR DESCRIPTION
Changes:
- Updated base image from Python 3.9 to 3.11
- Now using `requirements.txt` for installing dependencies

Test:
```sh
docker build -t birdnet-analyzer .
docker run --rm -it birdnet-analyzer
```
or using buildah and podman:
```sh
buildah build -t birdnet-analyzer .
podman run --rm -it birdnet-analyzer
```