### PR TITLE
Fix link to model versions history in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -235,7 +235,7 @@ You can access the map here: https://kahst.github.io/BirdNET-Analyzer/projects.h
 * enhanced and optimized metadata model
 * global selection of species (birds and non-birds) with 6,522 classes (incl. 10 non-event classes)
 
-You can find a list of previous versions here: https://github.com/kahst/BirdNET-Analyzer/tree/main/checkpoints[BirdNET-Analyzer Model Version History]
+You can find a list of previous versions here: https://github.com/kahst/BirdNET-Analyzer/tree/main/birdnet_analyzer/checkpoints[BirdNET-Analyzer Model Version History]
 
 [discrete]
 ==== Species range model V2.4 - V2, Jan 2024


### PR DESCRIPTION
Thank you so much for your work!

This fixes the link to model versions history in the README, which I think was outdated.

I hope this helps!