### PR TITLE
env: requirements.txt unsupported version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ tqdm
 bottle
 requests
 keras-tuner
-# below, to surpport birdnet_anaalyzer.gui
+# below, to support birdnet_anaalyzer.gui
 matplotlib==3.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 librosa==0.9.2
 resampy
-tensorflow==2.16.1
+tensorflow==2.16.2
 gradio==5.4.0
 pywebview
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 librosa==0.9.2
 resampy
-tensorflow==2.15.0
+tensorflow==2.16.1
 gradio==5.4.0
 pywebview
 tqdm
 bottle
 requests
 keras-tuner
+# below, to surpport birdnet_anaalyzer.gui
+matplotlib==3.9.3


### PR DESCRIPTION
Hello @kahst ! Thank you for your work on BirdNET! It’s a great resource for the community. 

I was trying this out locally & found some tweaks were needed in order to run `python -m birdnet_analyzer.gui`.

Currently (2024.12.10), on `main` branch, there will be an error when installing from requirements.txt on the following setup:

did `uname -a` on my macOS -> `Darwin KenMacPro.local 24.1.0 Darwin Kernel Version 24.1.0: Thu Oct 10 21:05:14 PDT 2024; root:xnu-11215.41.3~2/RELEASE_ARM64_T8103 arm64` 
using Python 3.12.3

Error I was trying to fix:
```
BirdNET-Analyzer git:(main) pip install -r requirements.txt
Collecting librosa==0.9.2 (from -r requirements.txt (line 1))
  Downloading librosa-0.9.2-py3-none-any.whl.metadata (8.2 kB)
Collecting resampy (from -r requirements.txt (line 2))
  Downloading resampy-0.4.3-py3-none-any.whl.metadata (3.0 kB)
ERROR: Could not find a version that satisfies the requirement tensorflow==2.15.0 (from versions: 2.16.0rc0, 2.16.1, 2.16.2, 2.17.0rc0, 2.17.0rc1, 2.17.0, 2.17.1, 2.18.0rc0, 2.18.0rc1, 2.18.0rc2, 2.18.0)
ERROR: No matching distribution found for tensorflow==2.15.0
```

This is because TensorFlow 2.15.0 may be no longer available from PyPI when installing in this fashion. This PR fixes this by going to the next minor version: 2.16.2. Trying with 2.18.0 also worked for me with my OS & python version mentioned above, if that’s preferrable...

I was able to play around with `gui` after this change, but am not familiar with the rest of the project yet to test further.

Additionally, in this PR `matplotlib` was added in order to allow running of `birdnet_analyzer.gui` thus avoiding errors such as this:

```
BirdNET-Analyzer git:(main) ✗ python -m birdnet_analyzer.gui
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/ken/Documents/wk/BirdNET-Analyzer/birdnet_analyzer/gui/__main__.py", line 5, in <module>
    import birdnet_analyzer.gui.train as train
  File "/Users/ken/Documents/wk/BirdNET-Analyzer/birdnet_analyzer/gui/train.py", line 7, in <module>
    import matplotlib.pyplot as plt
ModuleNotFoundError: No module named 'matplotlib'
```

Screenshots after updates:

<img width="1011" alt="Screenshot 2024-12-10 at 10 06 58 PM" src="https://github.com/user-attachments/assets/cbd20eb8-23c3-4894-be0a-f67e47456077">
<img width="989" alt="Screenshot 2024-12-10 at 10 07 07 PM" src="https://github.com/user-attachments/assets/94412bf3-8a7e-488a-aef8-5e44898bd58d">


Respectfully,
Ken