### PR TITLE
env: requirements.txt add matplotlib dependency for gui

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ tqdm
 bottle
 requests
 keras-tuner
+# below, to support birdnet_analyzer.gui
+matplotlib===3.9.3


### PR DESCRIPTION
In this PR `matplotlib` was added in order to allow running of `birdnet_analyzer.gui` thus avoiding errors such as this:

```
BirdNET-Analyzer git:(main) ✗ python -m birdnet_analyzer.gui
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/ken/Documents/wk/BirdNET-Analyzer/birdnet_analyzer/gui/__main__.py", line 5, in <module>
    import birdnet_analyzer.gui.train as train
  File "/Users/ken/Documents/wk/BirdNET-Analyzer/birdnet_analyzer/gui/train.py", line 7, in <module>
    import matplotlib.pyplot as plt
ModuleNotFoundError: No module named 'matplotlib'
```

This is a follow up to #525. Thank you, @Josef-Haupt for looking at and your feedback on that PR!

Tested on:
Python: `3.11.11`
OS: `Darwin Kernel Version 24.1.0: Thu Oct 10 21:05:14 PDT 2024; root:xnu-11215.41.3~2/RELEASE_ARM64_T8103 arm64`

```
python -m birdnet_analyzer.gui
```
Used this to analyze a Virgina Rail `.m4a` file that I recorded today nearby.

<img width="988" alt="Screenshot 2024-12-12 at 9 35 12 AM" src="https://github.com/user-attachments/assets/4282b8b1-b289-4708-bd8b-d14526b38b6f" />
<img width="978" alt="Screenshot 2024-12-12 at 9 35 21 AM" src="https://github.com/user-attachments/assets/9860698d-1059-4e69-9eae-d37be1cd753f" />

Thank you for your consideration! Ken
